### PR TITLE
Marathon recipe support

### DIFF
--- a/data/recipes.v15.json
+++ b/data/recipes.v15.json
@@ -1,2266 +1,3391 @@
 {
-    "file_version": 1.0,
-    "game_version": 0.13,
-    "data": [{
-        "id": "iron-ore",
+  "file_version": 1.0,
+  "game_version": 0.13,
+  "data": [
+    {
+      "id": "piercing-rounds-magazine",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 3,
+      "input": {
+        "firearm-magazine": 1,
+        "steel-plate": 1,
+        "copper-plate": 5
+      },
+      "output": {
+        "piercing-rounds-magazine": 1
+      }
+    },
+    {
+      "id": "uranium-rounds-magazine",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "piercing-rounds-magazine": 1,
+        "uranium-238": 1
+      },
+      "output": {
+        "uranium-rounds-magazine": 1
+      }
+    },
+    {
+      "id": "rocket",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 8,
+      "input": {
+        "electronic-circuit": 1,
+        "explosives": 1,
+        "iron-plate": 2
+      },
+      "output": {
+        "rocket": 1
+      }
+    },
+    {
+      "id": "explosive-rocket",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 8,
+      "input": {
+        "rocket": 1,
+        "explosives": 2
+      },
+      "output": {
+        "explosive-rocket": 1
+      }
+    },
+    {
+      "id": "atomic-bomb",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 50,
+      "input": {
+        "processing-unit": 20,
+        "explosives": 10,
+        "uranium-235": 30
+      },
+      "output": {
+        "atomic-bomb": 1
+      }
+    },
+    {
+      "id": "shotgun-shell",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 3,
+      "input": {
+        "copper-plate": 2,
+        "iron-plate": 2
+      },
+      "output": {
+        "shotgun-shell": 1
+      }
+    },
+    {
+      "id": "piercing-shotgun-shell",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 8,
+      "input": {
+        "shotgun-shell": 2,
+        "copper-plate": 5,
+        "steel-plate": 2
+      },
+      "output": {
+        "piercing-shotgun-shell": 1
+      }
+    },
+    {
+      "id": "railgun-dart",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 8,
+      "input": {
+        "steel-plate": 5,
+        "electronic-circuit": 5
+      },
+      "output": {
+        "railgun-dart": 1
+      }
+    },
+    {
+      "id": "cannon-shell",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "normal": {
+        "time": 8,
+        "input": {
+          "steel-plate": 2,
+          "plastic-bar": 2,
+          "explosives": 1
+        },
+        "output": {
+          "cannon-shell": 1
+        }
+      },
+      "expensive": {
+        "time": 8,
+        "input": {
+          "steel-plate": 4,
+          "plastic-bar": 4,
+          "explosives": 1
+        },
+        "output": {
+          "cannon-shell": 1
+        }
+      }
+    },
+    {
+      "id": "explosive-cannon-shell",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "normal": {
+        "time": 8,
+        "input": {
+          "steel-plate": 2,
+          "plastic-bar": 2,
+          "explosives": 2
+        },
+        "output": {
+          "explosive-cannon-shell": 1
+        }
+      },
+      "expensive": {
+        "time": 8,
+        "input": {
+          "steel-plate": 4,
+          "plastic-bar": 4,
+          "explosives": 2
+        },
+        "output": {
+          "explosive-cannon-shell": 1
+        }
+      }
+    },
+    {
+      "id": "uranium-cannon-shell",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 12,
+      "input": {
+        "cannon-shell": 1,
+        "uranium-238": 1
+      },
+      "output": {
+        "uranium-cannon-shell": 1
+      }
+    },
+    {
+      "id": "explosive-uranium-cannon-shell",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 12,
+      "input": {
+        "explosive-cannon-shell": 1,
+        "uranium-238": 1
+      },
+      "output": {
+        "explosive-uranium-cannon-shell": 1
+      }
+    },
+    {
+      "id": "flamethrower-ammo",
+      "building": [
+        "chemical-plant"
+      ],
+      "time": 6,
+      "input": {
+        "steel-plate": 5,
+        "light-oil": 50,
+        "heavy-oil": 50
+      },
+      "output": {
+        "flamethrower-ammo": 1
+      }
+    },
+    {
+      "id": "poison-capsule",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 8,
+      "input": {
+        "steel-plate": 3,
+        "electronic-circuit": 3,
+        "coal": 10
+      },
+      "output": {
+        "poison-capsule": 1
+      }
+    },
+    {
+      "id": "slowdown-capsule",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 8,
+      "input": {
+        "steel-plate": 2,
+        "electronic-circuit": 2,
+        "coal": 5
+      },
+      "output": {
+        "slowdown-capsule": 1
+      }
+    },
+    {
+      "id": "grenade",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 8,
+      "input": {
+        "iron-plate": 5,
+        "coal": 10
+      },
+      "output": {
+        "grenade": 1
+      }
+    },
+    {
+      "id": "cluster-grenade",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 8,
+      "input": {
+        "grenade": 7,
+        "explosives": 5,
+        "steel-plate": 5
+      },
+      "output": {
+        "cluster-grenade": 1
+      }
+    },
+    {
+      "id": "defender-capsule",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 8,
+      "input": {
+        "piercing-rounds-magazine": 1,
+        "electronic-circuit": 2,
+        "iron-gear-wheel": 3
+      },
+      "output": {
+        "defender-capsule": 1
+      }
+    },
+    {
+      "id": "distractor-capsule",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 15,
+      "input": {
+        "defender-capsule": 4,
+        "advanced-circuit": 3
+      },
+      "output": {
+        "distractor-capsule": 1
+      }
+    },
+    {
+      "id": "destroyer-capsule",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 15,
+      "input": {
+        "distractor-capsule": 4,
+        "speed-module": 1
+      },
+      "output": {
+        "destroyer-capsule": 1
+      }
+    },
+    {
+      "id": "discharge-defense-remote",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "electronic-circuit": 1
+      },
+      "output": {
+        "discharge-defense-remote": 1
+      }
+    },
+    {
+      "id": "copper-plate",
+      "building": [
+        "electric-furnace",
+        "steel-furnace",
+        "stone-furnace"
+      ],
+      "time": 3.5,
+      "input": {
+        "copper-ore": 1
+      },
+      "output": {
+        "copper-plate": 1
+      }
+    },
+    {
+      "id": "iron-plate",
+      "building": [
+        "electric-furnace",
+        "steel-furnace",
+        "stone-furnace"
+      ],
+      "time": 3.5,
+      "input": {
+        "iron-ore": 1
+      },
+      "output": {
+        "iron-plate": 1
+      }
+    },
+    {
+      "id": "stone-brick",
+      "building": [
+        "electric-furnace",
+        "steel-furnace",
+        "stone-furnace"
+      ],
+      "time": 3.5,
+      "input": {
+        "stone": 2
+      },
+      "output": {
+        "stone-brick": 1
+      }
+    },
+    {
+      "id": "wood",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "raw-wood": 1
+      },
+      "output": {
+        "wood": 2
+      }
+    },
+    {
+      "id": "wooden-chest",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "wood": 4
+      },
+      "output": {
+        "wooden-chest": 1
+      }
+    },
+    {
+      "id": "iron-stick",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "iron-plate": 1
+      },
+      "output": {
+        "iron-stick": 2
+      }
+    },
+    {
+      "id": "iron-axe",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "iron-stick": 2,
+        "iron-plate": 3
+      },
+      "output": {
+        "iron-axe": 1
+      }
+    },
+    {
+      "id": "stone-furnace",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "stone": 5
+      },
+      "output": {
+        "stone-furnace": 1
+      }
+    },
+    {
+      "id": "boiler",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "stone-furnace": 1,
+        "pipe": 4
+      },
+      "output": {
+        "boiler": 1
+      }
+    },
+    {
+      "id": "steam-engine",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "normal": {
+        "time": 0.5,
+        "input": {
+          "iron-gear-wheel": 8,
+          "pipe": 5,
+          "iron-plate": 10
+        },
+        "output": {
+          "steam-engine": 1
+        }
+      },
+      "expensive": {
+        "time": 0.5,
+        "input": {
+          "iron-gear-wheel": 10,
+          "pipe": 5,
+          "iron-plate": 50
+        },
+        "output": {
+          "steam-engine": 1
+        }
+      }
+    },
+    {
+      "id": "iron-gear-wheel",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "normal": {
+        "time": 0.5,
+        "input": {
+          "iron-plate": 2
+        },
+        "output": {
+          "iron-gear-wheel": 1
+        }
+      },
+      "expensive": {
+        "time": 0.5,
+        "input": {
+          "iron-plate": 4
+        },
+        "output": {
+          "iron-gear-wheel": 1
+        }
+      }
+    },
+    {
+      "id": "electronic-circuit",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "normal": {
+        "time": 0.5,
+        "input": {
+          "iron-plate": 1,
+          "copper-cable": 3
+        },
+        "output": {
+          "electronic-circuit": 1
+        }
+      },
+      "expensive": {
+        "time": 0.5,
+        "input": {
+          "iron-plate": 2,
+          "copper-cable": 10
+        },
+        "output": {
+          "electronic-circuit": 1
+        }
+      }
+    },
+    {
+      "id": "transport-belt",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "iron-plate": 1,
+        "iron-gear-wheel": 1
+      },
+      "output": {
+        "transport-belt": 2
+      }
+    },
+    {
+      "id": "electric-mining-drill",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "normal": {
         "time": 2,
-        "building": ["electric-mining-drill", "burner-mining-drill"],
-        "input": {},
+        "input": {
+          "electronic-circuit": 3,
+          "iron-gear-wheel": 5,
+          "iron-plate": 10
+        },
         "output": {
-            "iron-ore": 0.9
+          "electric-mining-drill": 1
         }
-    }, {
-        "id": "copper-ore",
+      },
+      "expensive": {
         "time": 2,
-        "building": ["electric-mining-drill", "burner-mining-drill"],
-        "input": {},
+        "input": {
+          "electronic-circuit": 5,
+          "iron-gear-wheel": 10,
+          "iron-plate": 20
+        },
         "output": {
-            "copper-ore": 0.9
+          "electric-mining-drill": 1
         }
-    }, {
-        "id": "coal",
+      }
+    },
+    {
+      "id": "burner-mining-drill",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "normal": {
         "time": 2,
-        "building": ["electric-mining-drill", "burner-mining-drill"],
-        "input": {},
-        "output": {
-            "coal": 0.9
-        }
-    }, {
-        "id": "stone",
-        "time": 2,
-        "building": ["electric-mining-drill", "burner-mining-drill"],
-        "input": {},
-        "output": {
-            "stone": 0.4
-        }
-    }, {
-        "id": "piercing-rounds-magazine",
-        "time": 3,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "firearm-magazine": 1,
-            "steel-plate": 1,
-            "copper-plate": 5
-        },
-        "output": {
-            "piercing-rounds-magazine": 1
-        }
-    }, {
-        "id": "uranium-rounds-magazine",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "piercing-rounds-magazine": 1,
-            "uranium-238": 1
-        },
-        "output": {
-            "uranium-rounds-magazine": 1
-        }
-    }, {
-        "id": "rocket",
-        "time": 8,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "electronic-circuit": 1,
-            "explosives": 1,
-            "iron-plate": 2
-        },
-        "output": {
-            "rocket": 1
-        }
-    }, {
-        "id": "explosive-rocket",
-        "time": 8,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "rocket": 1,
-            "explosives": 2
-        },
-        "output": {
-            "explosive-rocket": 1
-        }
-    }, {
-        "id": "atomic-bomb",
-        "time": 50,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "processing-unit": 20,
-            "explosives": 10,
-            "uranium-235": 30
-        },
-        "output": {
-            "atomic-bomb": 1
-        }
-    }, {
-        "id": "shotgun-shell",
-        "time": 3,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "copper-plate": 2,
-            "iron-plate": 2
-        },
-        "output": {
-            "shotgun-shell": 1
-        }
-    }, {
-        "id": "piercing-shotgun-shell",
-        "time": 8,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "shotgun-shell": 2,
-            "copper-plate": 5,
-            "steel-plate": 2
-        },
-        "output": {
-            "piercing-shotgun-shell": 1
-        }
-    }, {
-        "id": "railgun-dart",
-        "time": 8,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 5,
-            "electronic-circuit": 5
-        },
-        "output": {
-            "railgun-dart": 1
-        }
-    }, {
-        "id": "cannon-shell",
-        "time": 8,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 2,
-            "plastic-bar": 2,
-            "explosives": 1
-        },
-        "output": {
-            "cannon-shell": 1
-        }
-    }, {
-        "id": "explosive-cannon-shell",
-        "time": 8,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 2,
-            "plastic-bar": 2,
-            "explosives": 2
-        },
-        "output": {
-            "explosive-cannon-shell": 1
-        }
-    }, {
-        "id": "uranium-cannon-shell",
-        "time": 12,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "cannon-shell": 1,
-            "uranium-238": 1
-        },
-        "output": {
-            "uranium-cannon-shell": 1
-        }
-    }, {
-        "id": "explosive-uranium-cannon-shell",
-        "time": 12,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "explosive-cannon-shell": 1,
-            "uranium-238": 1
-        },
-        "output": {
-            "explosive-uranium-cannon-shell": 1
-        }
-    }, {
-        "id": "flamethrower-ammo",
-        "time": 6,
-        "building": ["chemical-plant"],
-        "input": {
-            "steel-plate": 5,
-            "light-oil": 50,
-            "heavy-oil": 50
-        },
-        "output": {
-            "flamethrower-ammo": 1
-        }
-    }, {
-        "id": "poison-capsule",
-        "time": 8,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 3,
-            "electronic-circuit": 3,
-            "coal": 10
-        },
-        "output": {
-            "poison-capsule": 1
-        }
-    }, {
-        "id": "slowdown-capsule",
-        "time": 8,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 2,
-            "electronic-circuit": 2,
-            "coal": 5
-        },
-        "output": {
-            "slowdown-capsule": 1
-        }
-    }, {
-        "id": "grenade",
-        "time": 8,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-plate": 5,
-            "coal": 10
-        },
-        "output": {
-            "grenade": 1
-        }
-    }, {
-        "id": "cluster-grenade",
-        "time": 8,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "grenade": 7,
-            "explosives": 5,
-            "steel-plate": 5
-        },
-        "output": {
-            "cluster-grenade": 1
-        }
-    }, {
-        "id": "defender-capsule",
-        "time": 8,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "piercing-rounds-magazine": 1,
-            "electronic-circuit": 2,
-            "iron-gear-wheel": 3
-        },
-        "output": {
-            "defender-capsule": 1
-        }
-    }, {
-        "id": "distractor-capsule",
-        "time": 15,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "defender-capsule": 4,
-            "advanced-circuit": 3
-        },
-        "output": {
-            "distractor-capsule": 1
-        }
-    }, {
-        "id": "destroyer-capsule",
-        "time": 15,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "distractor-capsule": 4,
-            "speed-module": 1
-        },
-        "output": {
-            "destroyer-capsule": 1
-        }
-    }, {
-        "id": "discharge-defense-remote",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "electronic-circuit": 1
-        },
-        "output": {
-            "discharge-defense-remote": 1
-        }
-    }, {
-        "id": "copper-plate",
-        "time": 3,
-        "building": ["electric-furnace", "steel-furnace", "stone-furnace"],
-        "input": {
-            "copper-ore": 1
-        },
-        "output": {
-            "copper-plate": 1
-        }
-    }, {
-        "id": "iron-plate",
-        "time": 3,
-        "building": ["electric-furnace", "steel-furnace", "stone-furnace"],
-        "input": {
-            "iron-ore": 1
-        },
-        "output": {
-            "iron-plate": 1
-        }
-    }, {
-        "id": "stone-brick",
-        "time": 3,
-        "building": ["electric-furnace", "steel-furnace", "stone-furnace"],
-        "input": {
-            "stone": 2
-        },
-        "output": {
-            "stone-brick": 1
-        }
-    }, {
-        "id": "wood",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "raw-wood": 1
-        },
-        "output": {
-            "wood": 2
-        }
-    }, {
-        "id": "wooden-chest",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "wood": 4
-        },
-        "output": {
-            "wooden-chest": 1
-        }
-    }, {
-        "id": "iron-stick",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-plate": 1
-        },
-        "output": {
-            "iron-stick": 2
-        }
-    }, {
-        "id": "iron-axe",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-stick": 2,
-            "iron-plate": 3
-        },
-        "output": {
-            "iron-axe": 1
-        }
-    }, {
-        "id": "stone-furnace",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "stone": 5
-        },
-        "output": {
-            "stone-furnace": 1
-        }
-    }, {
-        "id": "boiler",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "stone-furnace": 1,
-            "pipe": 4
-        },
-        "output": {
-            "boiler": 1
-        }
-    }, {
-        "id": "steam-engine",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-gear-wheel": 8,
-            "pipe": 5,
-            "iron-plate": 10
-        },
-        "output": {
-            "steam-engine": 1
-        }
-    }, {
-        "id": "iron-gear-wheel",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-plate": 2
-        },
-        "output": {
-            "iron-gear-wheel": 1
-        }
-    }, {
-        "id": "electronic-circuit",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-plate": 1,
-            "copper-cable": 3
-        },
-        "output": {
-            "electronic-circuit": 1
-        }
-    }, {
-        "id": "transport-belt",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-plate": 1,
-            "iron-gear-wheel": 1
-        },
-        "output": {
-            "transport-belt": 2
-        }
-    }, {
-        "id": "electric-mining-drill",
-        "time": 2,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "electronic-circuit": 3,
-            "iron-gear-wheel": 5,
-            "iron-plate": 10
-        },
-        "output": {
-            "electric-mining-drill": 1
-        }
-    }, {
-        "id": "burner-mining-drill",
-        "time": 2,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-gear-wheel": 3,
-            "stone-furnace": 1,
-            "iron-plate": 3
-        },
-        "output": {
-            "burner-mining-drill": 1
-        }
-    }, {
-        "id": "inserter",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "electronic-circuit": 1,
-            "iron-gear-wheel": 1,
-            "iron-plate": 1
-        },
-        "output": {
-            "inserter": 1
-        }
-    }, {
-        "id": "burner-inserter",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-plate": 1,
-            "iron-gear-wheel": 1
-        },
-        "output": {
-            "burner-inserter": 1
-        }
-    }, {
-        "id": "pipe",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-plate": 1
-        },
-        "output": {
-            "pipe": 1
-        }
-    }, {
-        "id": "offshore-pump",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "electronic-circuit": 2,
-            "pipe": 1,
-            "iron-gear-wheel": 1
-        },
-        "output": {
-            "offshore-pump": 1
-        }
-    }, {
-        "id": "copper-cable",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "copper-plate": 1
-        },
-        "output": {
-            "copper-cable": 2
-        }
-    }, {
-        "id": "small-electric-pole",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "wood": 2,
-            "copper-cable": 2
-        },
-        "output": {
-            "small-electric-pole": 2
-        }
-    }, {
-        "id": "pistol",
-        "time": 5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "copper-plate": 5,
-            "iron-plate": 5
-        },
-        "output": {
-            "pistol": 1
-        }
-    }, {
-        "id": "submachine-gun",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-gear-wheel": 10,
-            "copper-plate": 5,
-            "iron-plate": 10
-        },
-        "output": {
-            "submachine-gun": 1
-        }
-    }, {
-        "id": "firearm-magazine",
-        "time": 1,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-plate": 4
-        },
-        "output": {
-            "firearm-magazine": 1
-        }
-    }, {
-        "id": "light-armor",
-        "time": 3,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-plate": 40
-        },
-        "output": {
-            "light-armor": 1
-        }
-    }, {
-        "id": "radar",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "electronic-circuit": 5,
-            "iron-gear-wheel": 5,
-            "iron-plate": 10
-        },
-        "output": {
-            "radar": 1
-        }
-    }, {
-        "id": "small-lamp",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "electronic-circuit": 1,
-            "iron-stick": 3,
-            "iron-plate": 1
-        },
-        "output": {
-            "small-lamp": 1
-        }
-    }, {
-        "id": "pipe-to-ground",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "pipe": 10,
-            "iron-plate": 5
-        },
-        "output": {
-            "pipe-to-ground": 2
-        }
-    }, {
-        "id": "assembling-machine-1",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "electronic-circuit": 3,
-            "iron-gear-wheel": 5,
-            "iron-plate": 9
-        },
-        "output": {
-            "assembling-machine-1": 1
-        }
-    }, {
-        "id": "repair-pack",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "electronic-circuit": 2,
-            "iron-gear-wheel": 2
-        },
-        "output": {
-            "repair-pack": 1
-        }
-    }, {
-        "id": "gun-turret",
-        "time": 8,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-gear-wheel": 10,
-            "copper-plate": 10,
-            "iron-plate": 20
-        },
-        "output": {
-            "gun-turret": 1
-        }
-    }, {
-        "id": "night-vision-equipment",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "advanced-circuit": 5,
-            "steel-plate": 10
-        },
-        "output": {
-            "night-vision-equipment": 1
-        }
-    }, {
-        "id": "energy-shield-equipment",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "advanced-circuit": 5,
-            "steel-plate": 10
-        },
-        "output": {
-            "energy-shield-equipment": 1
-        }
-    }, {
-        "id": "energy-shield-mk2-equipment",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "energy-shield-equipment": 10,
-            "processing-unit": 10
-        },
-        "output": {
-            "energy-shield-mk2-equipment": 1
-        }
-    }, {
-        "id": "battery-equipment",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "battery": 5,
-            "steel-plate": 10
-        },
-        "output": {
-            "battery-equipment": 1
-        }
-    }, {
-        "id": "battery-mk2-equipment",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "battery-equipment": 10,
-            "processing-unit": 20
-        },
-        "output": {
-            "battery-mk2-equipment": 1
-        }
-    }, {
-        "id": "solar-panel-equipment",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "solar-panel": 5,
-            "advanced-circuit": 1,
-            "steel-plate": 5
-        },
-        "output": {
-            "solar-panel-equipment": 1
-        }
-    }, {
-        "id": "fusion-reactor-equipment",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "processing-unit": 250
-        },
-        "output": {
-            "fusion-reactor-equipment": 1
-        }
-    }, {
-        "id": "personal-laser-defense-equipment",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "processing-unit": 1,
-            "steel-plate": 5,
-            "laser-turret": 5
-        },
-        "output": {
-            "personal-laser-defense-equipment": 1
-        }
-    }, {
-        "id": "discharge-defense-equipment",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "processing-unit": 5,
-            "steel-plate": 20,
-            "laser-turret": 10
-        },
-        "output": {
-            "discharge-defense-equipment": 1
-        }
-    }, {
-        "id": "exoskeleton-equipment",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "processing-unit": 10,
-            "electric-engine-unit": 30,
-            "steel-plate": 20
-        },
-        "output": {
-            "exoskeleton-equipment": 1
-        }
-    }, {
-        "id": "personal-roboport-equipment",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "advanced-circuit": 10,
-            "iron-gear-wheel": 40,
-            "steel-plate": 20,
-            "battery": 45
-        },
-        "output": {
-            "personal-roboport-equipment": 1
-        }
-    }, {
-        "id": "personal-roboport-mk2-equipment",
-        "time": 20,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "personal-roboport-equipment": 5,
-            "processing-unit": 100
-        },
-        "output": {
-            "personal-roboport-mk2-equipment": 1
-        }
-    }, {
-        "id": "basic-oil-processing",
-        "time": 5,
-        "building": ["oil-refinery"],
-        "input": {
-            "crude-oil": 100
-        },
-        "output": {
-            "heavy-oil": 30,
-            "light-oil": 30,
-            "petroleum-gas": 40
-        }
-    }, {
-        "id": "advanced-oil-processing",
-        "time": 5,
-        "building": ["oil-refinery"],
-        "input": {
-            "water": 50,
-            "crude-oil": 100
-        },
-        "output": {
-            "heavy-oil": 10,
-            "light-oil": 45,
-            "petroleum-gas": 55
-        }
-    }, {
-        "id": "coal-liquefaction",
-        "time": 5,
-        "building": ["oil-refinery"],
-        "input": {
-            "coal": 10,
-            "heavy-oil": 25,
-            "steam": 50
-        },
-        "output": {
-            "heavy-oil": 35,
-            "light-oil": 15,
-            "petroleum-gas": 20
-        }
-    }, {
-        "id": "heavy-oil-cracking",
-        "time": 3,
-        "building": ["chemical-plant"],
-        "input": {
-            "water": 30,
-            "heavy-oil": 40
-        },
-        "output": {
-            "light-oil": 30
-        }
-    }, {
-        "id": "light-oil-cracking",
-        "time": 3,
-        "building": ["chemical-plant"],
-        "input": {
-            "water": 30,
-            "light-oil": 30
-        },
-        "output": {
-            "petroleum-gas": 20
-        }
-    }, {
-        "id": "sulfuric-acid",
-        "time": 1,
-        "building": ["chemical-plant"],
-        "input": {
-            "sulfur": 5,
-            "iron-plate": 1,
-            "water": 100
-        },
-        "output": {
-            "sulfuric-acid": 50
-        }
-    }, {
-        "id": "plastic-bar",
-        "time": 1,
-        "building": ["chemical-plant"],
-        "input": {
-            "petroleum-gas": 20,
-            "coal": 1
-        },
-        "output": {
-            "plastic-bar": 2
-        }
-    }, {
-        "id": "solid-fuel-from-light-oil",
-        "time": 3,
-        "building": ["chemical-plant"],
-        "input": {
-            "light-oil": 10
-        },
-        "output": {
-            "solid-fuel": 1
-        }
-    }, {
-        "id": "solid-fuel-from-petroleum-gas",
-        "time": 3,
-        "building": ["chemical-plant"],
-        "input": {
-            "petroleum-gas": 20
-        },
-        "output": {
-            "solid-fuel": 1
-        }
-    }, {
-        "id": "solid-fuel-from-heavy-oil",
-        "time": 3,
-        "building": ["chemical-plant"],
-        "input": {
-            "heavy-oil": 20
-        },
-        "output": {
-            "solid-fuel": 1
-        }
-    }, {
-        "id": "sulfur",
-        "time": 1,
-        "building": ["chemical-plant"],
-        "input": {
-            "water": 30,
-            "petroleum-gas": 30
-        },
-        "output": {
-            "sulfur": 2
-        }
-    }, {
-        "id": "lubricant",
-        "time": 1,
-        "building": ["chemical-plant"],
-        "input": {
-            "heavy-oil": 10
-        },
-        "output": {
-            "lubricant": 10
-        }
-    }, {
-        "id": "empty-barrel",
-        "time": 1,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 1
-        },
-        "output": {
-            "empty-barrel": 1
-        }
-    }, {
-        "id": "steel-plate",
-        "time": 17,
-        "building": ["electric-furnace", "steel-furnace", "stone-furnace"],
-        "input": {
-            "iron-plate": 5
-        },
-        "output": {
-            "steel-plate": 1
-        }
-    }, {
-        "id": "long-handed-inserter",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-gear-wheel": 1,
-            "iron-plate": 1,
-            "inserter": 1
-        },
-        "output": {
-            "long-handed-inserter": 1
-        }
-    }, {
-        "id": "fast-inserter",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "electronic-circuit": 2,
-            "iron-plate": 2,
-            "inserter": 1
-        },
-        "output": {
-            "fast-inserter": 1
-        }
-    }, {
-        "id": "filter-inserter",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "fast-inserter": 1,
-            "electronic-circuit": 4
-        },
-        "output": {
-            "filter-inserter": 1
-        }
-    }, {
-        "id": "stack-inserter",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-gear-wheel": 15,
-            "electronic-circuit": 15,
-            "advanced-circuit": 1,
-            "fast-inserter": 1
-        },
-        "output": {
-            "stack-inserter": 1
-        }
-    }, {
-        "id": "stack-filter-inserter",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "stack-inserter": 1,
-            "electronic-circuit": 5
-        },
-        "output": {
-            "stack-filter-inserter": 1
-        }
-    }, {
-        "id": "speed-module",
-        "time": 15,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "advanced-circuit": 5,
-            "electronic-circuit": 5
-        },
-        "output": {
-            "speed-module": 1
-        }
-    }, {
-        "id": "speed-module-2",
-        "time": 30,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "speed-module": 4,
-            "advanced-circuit": 5,
-            "processing-unit": 5
-        },
-        "output": {
-            "speed-module-2": 1
-        }
-    }, {
-        "id": "speed-module-3",
-        "time": 60,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "speed-module-2": 5,
-            "advanced-circuit": 5,
-            "processing-unit": 5
-        },
-        "output": {
-            "speed-module-3": 1
-        }
-    }, {
-        "id": "productivity-module",
-        "time": 15,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "advanced-circuit": 5,
-            "electronic-circuit": 5
-        },
-        "output": {
-            "productivity-module": 1
-        }
-    }, {
-        "id": "productivity-module-2",
-        "time": 30,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "productivity-module": 4,
-            "advanced-circuit": 5,
-            "processing-unit": 5
-        },
-        "output": {
-            "productivity-module-2": 1
-        }
-    }, {
-        "id": "productivity-module-3",
-        "time": 60,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "productivity-module-2": 5,
-            "advanced-circuit": 5,
-            "processing-unit": 5
-        },
-        "output": {
-            "productivity-module-3": 1
-        }
-    }, {
-        "id": "effectivity-module",
-        "time": 15,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "advanced-circuit": 5,
-            "electronic-circuit": 5
-        },
-        "output": {
-            "effectivity-module": 1
-        }
-    }, {
-        "id": "effectivity-module-2",
-        "time": 30,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "effectivity-module": 4,
-            "advanced-circuit": 5,
-            "processing-unit": 5
-        },
-        "output": {
-            "effectivity-module-2": 1
-        }
-    }, {
-        "id": "effectivity-module-3",
-        "time": 60,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "effectivity-module-2": 5,
-            "advanced-circuit": 5,
-            "processing-unit": 5
-        },
-        "output": {
-            "effectivity-module-3": 1
-        }
-    }, {
-        "id": "player-port",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "electronic-circuit": 10,
-            "iron-gear-wheel": 5,
-            "iron-plate": 1
-        },
-        "output": {
-            "player-port": 1
-        }
-    }, {
-        "id": "fast-transport-belt",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-gear-wheel": 5,
-            "transport-belt": 1
-        },
-        "output": {
-            "fast-transport-belt": 1
-        }
-    }, {
-        "id": "express-transport-belt",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-gear-wheel": 10,
-            "fast-transport-belt": 1,
-            "lubricant": 20
-        },
-        "output": {
-            "express-transport-belt": 1
-        }
-    }, {
-        "id": "solar-panel",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 5,
-            "electronic-circuit": 15,
-            "copper-plate": 5
-        },
-        "output": {
-            "solar-panel": 1
-        }
-    }, {
-        "id": "assembling-machine-2",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-plate": 9,
-            "electronic-circuit": 3,
-            "iron-gear-wheel": 5,
-            "assembling-machine-1": 1
-        },
-        "output": {
-            "assembling-machine-2": 1
-        }
-    }, {
-        "id": "assembling-machine-3",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "speed-module": 4,
-            "assembling-machine-2": 2
-        },
-        "output": {
-            "assembling-machine-3": 1
-        }
-    }, {
-        "id": "car",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "engine-unit": 8,
-            "iron-plate": 20,
-            "steel-plate": 5
-        },
-        "output": {
-            "car": 1
-        }
-    }, {
-        "id": "tank",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "engine-unit": 32,
-            "steel-plate": 50,
-            "iron-gear-wheel": 15,
-            "advanced-circuit": 10
-        },
-        "output": {
-            "tank": 1
-        }
-    }, {
-        "id": "rail",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "stone": 1,
-            "iron-stick": 1,
-            "steel-plate": 1
-        },
-        "output": {
-            "rail": 2
-        }
-    }, {
-        "id": "locomotive",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "engine-unit": 20,
-            "electronic-circuit": 10,
-            "steel-plate": 30
-        },
-        "output": {
-            "locomotive": 1
-        }
-    }, {
-        "id": "cargo-wagon",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-gear-wheel": 10,
-            "iron-plate": 20,
-            "steel-plate": 20
-        },
-        "output": {
-            "cargo-wagon": 1
-        }
-    }, {
-        "id": "fluid-wagon",
-        "time": 1,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-gear-wheel": 10,
-            "steel-plate": 16,
-            "pipe": 8,
-            "storage-tank": 3
-        },
-        "output": {
-            "fluid-wagon": 1
-        }
-    }, {
-        "id": "train-stop",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "electronic-circuit": 5,
-            "iron-plate": 10,
-            "steel-plate": 3
-        },
-        "output": {
-            "train-stop": 1
-        }
-    }, {
-        "id": "rail-signal",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "electronic-circuit": 1,
-            "iron-plate": 5
-        },
-        "output": {
-            "rail-signal": 1
-        }
-    }, {
-        "id": "rail-chain-signal",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "electronic-circuit": 1,
-            "iron-plate": 5
-        },
-        "output": {
-            "rail-chain-signal": 1
-        }
-    }, {
-        "id": "heavy-armor",
-        "time": 8,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "copper-plate": 100,
-            "steel-plate": 50
-        },
-        "output": {
-            "heavy-armor": 1
-        }
-    }, {
-        "id": "modular-armor",
-        "time": 15,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "advanced-circuit": 30,
-            "steel-plate": 50
-        },
-        "output": {
-            "modular-armor": 1
-        }
-    }, {
-        "id": "power-armor",
-        "time": 20,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "processing-unit": 40,
-            "electric-engine-unit": 20,
-            "steel-plate": 40
-        },
-        "output": {
-            "power-armor": 1
-        }
-    }, {
-        "id": "power-armor-mk2",
-        "time": 25,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "effectivity-module-3": 5,
-            "speed-module-3": 5,
-            "processing-unit": 40,
-            "steel-plate": 40
-        },
-        "output": {
-            "power-armor-mk2": 1
-        }
-    }, {
-        "id": "iron-chest",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-plate": 8
-        },
-        "output": {
-            "iron-chest": 1
-        }
-    }, {
-        "id": "steel-chest",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 8
-        },
-        "output": {
-            "steel-chest": 1
-        }
-    }, {
-        "id": "stone-wall",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "stone-brick": 5
-        },
-        "output": {
-            "stone-wall": 1
-        }
-    }, {
-        "id": "gate",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "stone-wall": 1,
-            "steel-plate": 2,
-            "electronic-circuit": 2
-        },
-        "output": {
-            "gate": 1
-        }
-    }, {
-        "id": "flamethrower",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 5,
-            "iron-gear-wheel": 10
-        },
-        "output": {
-            "flamethrower": 1
-        }
-    }, {
-        "id": "land-mine",
-        "time": 5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 1,
-            "explosives": 2
-        },
-        "output": {
-            "land-mine": 4
-        }
-    }, {
-        "id": "rocket-launcher",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-plate": 5,
-            "iron-gear-wheel": 5,
-            "electronic-circuit": 5
-        },
-        "output": {
-            "rocket-launcher": 1
-        }
-    }, {
-        "id": "shotgun",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-plate": 15,
-            "iron-gear-wheel": 5,
-            "copper-plate": 10,
-            "wood": 5
-        },
-        "output": {
-            "shotgun": 1
-        }
-    }, {
-        "id": "combat-shotgun",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 15,
-            "iron-gear-wheel": 5,
-            "copper-plate": 10,
-            "wood": 10
-        },
-        "output": {
-            "combat-shotgun": 1
-        }
-    }, {
-        "id": "railgun",
-        "time": 8,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 15,
-            "copper-plate": 15,
-            "electronic-circuit": 10,
-            "advanced-circuit": 5
-        },
-        "output": {
-            "railgun": 1
-        }
-    }, {
-        "id": "science-pack-1",
-        "time": 5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "copper-plate": 1,
-            "iron-gear-wheel": 1
-        },
-        "output": {
-            "science-pack-1": 1
-        }
-    }, {
-        "id": "science-pack-2",
-        "time": 6,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "inserter": 1,
-            "transport-belt": 1
-        },
-        "output": {
-            "science-pack-2": 1
-        }
-    }, {
-        "id": "science-pack-3",
-        "time": 12,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "advanced-circuit": 1,
-            "engine-unit": 1,
-            "electric-mining-drill": 1
-        },
-        "output": {
-            "science-pack-3": 1
-        }
-    }, {
-        "id": "military-science-pack",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "piercing-rounds-magazine": 1,
-            "grenade": 1,
-            "gun-turret": 1
-        },
-        "output": {
-            "military-science-pack": 2
-        }
-    }, {
-        "id": "production-science-pack",
-        "time": 14,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "electric-engine-unit": 1,
-            "assembling-machine-1": 1,
-            "electric-furnace": 1
-        },
-        "output": {
-            "production-science-pack": 2
-        }
-    }, {
-        "id": "high-tech-science-pack",
-        "time": 14,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "battery": 1,
-            "processing-unit": 3,
-            "speed-module": 1,
-            "copper-cable": 30
-        },
-        "output": {
-            "high-tech-science-pack": 2
-        }
-    }, {
-        "id": "lab",
-        "time": 3,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "electronic-circuit": 10,
-            "iron-gear-wheel": 10,
-            "transport-belt": 4
-        },
-        "output": {
-            "lab": 1
-        }
-    }, {
-        "id": "red-wire",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "electronic-circuit": 1,
-            "copper-cable": 1
-        },
-        "output": {
-            "red-wire": 1
-        }
-    }, {
-        "id": "green-wire",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "electronic-circuit": 1,
-            "copper-cable": 1
-        },
-        "output": {
-            "green-wire": 1
-        }
-    }, {
-        "id": "underground-belt",
-        "time": 1,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-plate": 10,
-            "transport-belt": 5
-        },
-        "output": {
-            "underground-belt": 2
-        }
-    }, {
-        "id": "fast-underground-belt",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-gear-wheel": 40,
-            "underground-belt": 2
-        },
-        "output": {
-            "fast-underground-belt": 2
-        }
-    }, {
-        "id": "express-underground-belt",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-gear-wheel": 80,
-            "fast-underground-belt": 2,
-            "lubricant": 40
-        },
-        "output": {
-            "express-underground-belt": 2
-        }
-    }, {
-        "id": "loader",
-        "time": 1,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "inserter": 5,
-            "electronic-circuit": 5,
-            "iron-gear-wheel": 5,
-            "iron-plate": 5,
-            "transport-belt": 5
-        },
-        "output": {
-            "loader": 1
-        }
-    }, {
-        "id": "fast-loader",
-        "time": 3,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "fast-transport-belt": 5,
-            "loader": 1
-        },
-        "output": {
-            "fast-loader": 1
-        }
-    }, {
-        "id": "express-loader",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "express-transport-belt": 5,
-            "fast-loader": 1
-        },
-        "output": {
-            "express-loader": 1
-        }
-    }, {
-        "id": "splitter",
-        "time": 1,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "electronic-circuit": 5,
-            "iron-plate": 5,
-            "transport-belt": 4
-        },
-        "output": {
-            "splitter": 1
-        }
-    }, {
-        "id": "fast-splitter",
-        "time": 2,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "splitter": 1,
-            "iron-gear-wheel": 10,
-            "electronic-circuit": 10
-        },
-        "output": {
-            "fast-splitter": 1
-        }
-    }, {
-        "id": "express-splitter",
-        "time": 2,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "fast-splitter": 1,
-            "iron-gear-wheel": 10,
-            "advanced-circuit": 10,
-            "lubricant": 80
-        },
-        "output": {
-            "express-splitter": 1
-        }
-    }, {
-        "id": "advanced-circuit",
-        "time": 6,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "electronic-circuit": 2,
-            "plastic-bar": 2,
-            "copper-cable": 4
-        },
-        "output": {
-            "advanced-circuit": 1
-        }
-    }, {
-        "id": "processing-unit",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "electronic-circuit": 20,
-            "advanced-circuit": 2,
-            "sulfuric-acid": 5
-        },
-        "output": {
-            "processing-unit": 1
-        }
-    }, {
-        "id": "logistic-robot",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "flying-robot-frame": 1,
-            "advanced-circuit": 2
-        },
-        "output": {
-            "logistic-robot": 1
-        }
-    }, {
-        "id": "construction-robot",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "flying-robot-frame": 1,
-            "electronic-circuit": 2
-        },
-        "output": {
-            "construction-robot": 1
-        }
-    }, {
-        "id": "logistic-chest-passive-provider",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-chest": 1,
-            "electronic-circuit": 3,
-            "advanced-circuit": 1
-        },
-        "output": {
-            "logistic-chest-passive-provider": 1
-        }
-    }, {
-        "id": "logistic-chest-active-provider",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-chest": 1,
-            "electronic-circuit": 3,
-            "advanced-circuit": 1
-        },
-        "output": {
-            "logistic-chest-active-provider": 1
-        }
-    }, {
-        "id": "logistic-chest-storage",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-chest": 1,
-            "electronic-circuit": 3,
-            "advanced-circuit": 1
-        },
-        "output": {
-            "logistic-chest-storage": 1
-        }
-    }, {
-        "id": "logistic-chest-requester",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-chest": 1,
-            "electronic-circuit": 3,
-            "advanced-circuit": 1
-        },
-        "output": {
-            "logistic-chest-requester": 1
-        }
-    }, {
-        "id": "rocket-silo",
-        "time": 30,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 1000,
-            "concrete": 1000,
-            "pipe": 100,
-            "processing-unit": 200,
-            "electric-engine-unit": 200
-        },
-        "output": {
-            "rocket-silo": 1
-        }
-    }, {
-        "id": "roboport",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 45,
-            "iron-gear-wheel": 45,
-            "advanced-circuit": 45
-        },
-        "output": {
-            "roboport": 1
-        }
-    }, {
-        "id": "steel-axe",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 5,
-            "iron-stick": 2
-        },
-        "output": {
-            "steel-axe": 1
-        }
-    }, {
-        "id": "big-electric-pole",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 5,
-            "copper-plate": 5
-        },
-        "output": {
-            "big-electric-pole": 1
-        }
-    }, {
-        "id": "substation",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 10,
-            "advanced-circuit": 5,
-            "copper-plate": 5
-        },
-        "output": {
-            "substation": 1
-        }
-    }, {
-        "id": "medium-electric-pole",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 2,
-            "copper-plate": 2
-        },
-        "output": {
-            "medium-electric-pole": 1
-        }
-    }, {
-        "id": "accumulator",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-plate": 2,
-            "battery": 5
-        },
-        "output": {
-            "accumulator": 1
-        }
-    }, {
-        "id": "steel-furnace",
-        "time": 3,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 6,
-            "stone-brick": 10
-        },
-        "output": {
-            "steel-furnace": 1
-        }
-    }, {
-        "id": "electric-furnace",
-        "time": 5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 10,
-            "advanced-circuit": 5,
-            "stone-brick": 10
-        },
-        "output": {
-            "electric-furnace": 1
-        }
-    }, {
-        "id": "beacon",
-        "time": 15,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "electronic-circuit": 20,
-            "advanced-circuit": 20,
-            "steel-plate": 10,
-            "copper-cable": 10
-        },
-        "output": {
-            "beacon": 1
-        }
-    }, {
-        "id": "pumpjack",
-        "time": 5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 5,
-            "iron-gear-wheel": 10,
-            "electronic-circuit": 5,
-            "pipe": 10
-        },
-        "output": {
-            "pumpjack": 1
-        }
-    }, {
-        "id": "oil-refinery",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 15,
-            "iron-gear-wheel": 10,
-            "stone-brick": 10,
-            "electronic-circuit": 10,
-            "pipe": 10
-        },
-        "output": {
-            "oil-refinery": 1
-        }
-    }, {
-        "id": "engine-unit",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 1,
-            "iron-gear-wheel": 1,
-            "pipe": 2
-        },
-        "output": {
-            "engine-unit": 1
-        }
-    }, {
-        "id": "electric-engine-unit",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "engine-unit": 1,
-            "lubricant": 15,
-            "electronic-circuit": 2
-        },
-        "output": {
-            "electric-engine-unit": 1
-        }
-    }, {
-        "id": "flying-robot-frame",
-        "time": 20,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "electric-engine-unit": 1,
-            "battery": 2,
-            "steel-plate": 1,
-            "electronic-circuit": 3
-        },
-        "output": {
-            "flying-robot-frame": 1
-        }
-    }, {
-        "id": "explosives",
-        "time": 5,
-        "building": ["chemical-plant"],
-        "input": {
-            "sulfur": 1,
-            "coal": 1,
-            "water": 10
-        },
-        "output": {
-            "explosives": 1
-        }
-    }, {
-        "id": "battery",
-        "time": 5,
-        "building": ["chemical-plant"],
-        "input": {
-            "sulfuric-acid": 20,
-            "iron-plate": 1,
-            "copper-plate": 1
-        },
-        "output": {
-            "battery": 1
-        }
-    }, {
-        "id": "storage-tank",
-        "time": 3,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-plate": 20,
-            "steel-plate": 5
-        },
-        "output": {
-            "storage-tank": 1
-        }
-    }, {
-        "id": "pump",
-        "time": 2,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "engine-unit": 1,
-            "steel-plate": 1,
-            "pipe": 1
-        },
-        "output": {
-            "pump": 1
-        }
-    }, {
-        "id": "chemical-plant",
-        "time": 5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 5,
-            "iron-gear-wheel": 5,
-            "electronic-circuit": 5,
-            "pipe": 5
-        },
-        "output": {
-            "chemical-plant": 1
-        }
-    }, {
-        "id": "small-plane",
-        "time": 30,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "plastic-bar": 100,
-            "advanced-circuit": 200,
-            "electric-engine-unit": 20,
-            "battery": 100
-        },
-        "output": {
-            "small-plane": 1
-        }
-    }, {
-        "id": "arithmetic-combinator",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "copper-cable": 5,
-            "electronic-circuit": 5
-        },
-        "output": {
-            "arithmetic-combinator": 1
-        }
-    }, {
-        "id": "decider-combinator",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "copper-cable": 5,
-            "electronic-circuit": 5
-        },
-        "output": {
-            "decider-combinator": 1
-        }
-    }, {
-        "id": "constant-combinator",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "copper-cable": 5,
-            "electronic-circuit": 2
-        },
-        "output": {
-            "constant-combinator": 1
-        }
-    }, {
-        "id": "power-switch",
-        "time": 2,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-plate": 5,
-            "copper-cable": 5,
-            "electronic-circuit": 2
-        },
-        "output": {
-            "power-switch": 1
-        }
-    }, {
-        "id": "programmable-speaker",
-        "time": 2,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "iron-plate": 5,
-            "copper-cable": 5,
-            "electronic-circuit": 4
-        },
-        "output": {
-            "programmable-speaker": 1
-        }
-    }, {
-        "id": "low-density-structure",
-        "time": 30,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "steel-plate": 10,
-            "copper-plate": 5,
-            "plastic-bar": 5
-        },
-        "output": {
-            "low-density-structure": 1
-        }
-    }, {
-        "id": "rocket-fuel",
-        "time": 30,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "solid-fuel": 10
-        },
-        "output": {
-            "rocket-fuel": 1
-        }
-    }, {
-        "id": "rocket-control-unit",
-        "time": 30,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "processing-unit": 1,
-            "speed-module": 1
-        },
-        "output": {
-            "rocket-control-unit": 1
-        }
-    }, {
-        "id": "rocket-part",
-        "time": 3,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "low-density-structure": 10,
-            "rocket-fuel": 10,
-            "rocket-control-unit": 10
-        },
-        "output": {
-            "rocket-part": 1
-        }
-    }, {
-        "id": "satellite",
-        "time": 3,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "low-density-structure": 100,
-            "solar-panel": 100,
-            "accumulator": 100,
-            "radar": 5,
-            "processing-unit": 100,
-            "rocket-fuel": 50
-        },
-        "output": {
-            "satellite": 1
-        }
-    }, {
-        "id": "concrete",
-        "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "stone-brick": 5,
-            "iron-ore": 1,
-            "water": 100
-        },
-        "output": {
-            "concrete": 10
-        }
-    }, {
-        "id": "hazard-concrete",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "concrete": 10
-        },
-        "output": {
-            "hazard-concrete": 10
-        }
-    }, {
-        "id": "landfill",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "stone": 20
-        },
-        "output": {
-            "landfill": 1
-        }
-    }, {
-        "id": "electric-energy-interface",
-        "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
         "input": {
-            "iron-plate": 2,
-            "electronic-circuit": 5
+          "iron-gear-wheel": 3,
+          "stone-furnace": 1,
+          "iron-plate": 3
         },
         "output": {
-            "electric-energy-interface": 1
+          "burner-mining-drill": 1
         }
-    }, {
-        "id": "nuclear-reactor",
+      },
+      "expensive": {
         "time": 4,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
         "input": {
-            "concrete": 500,
-            "steel-plate": 500,
-            "advanced-circuit": 500,
-            "copper-plate": 500
+          "iron-gear-wheel": 6,
+          "stone-furnace": 2,
+          "iron-plate": 6
         },
         "output": {
-            "nuclear-reactor": 1
+          "burner-mining-drill": 1
         }
-    }, {
-        "id": "centrifuge",
-        "time": 4,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
+      }
+    },
+    {
+      "id": "inserter",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "electronic-circuit": 1,
+        "iron-gear-wheel": 1,
+        "iron-plate": 1
+      },
+      "output": {
+        "inserter": 1
+      }
+    },
+    {
+      "id": "burner-inserter",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "iron-plate": 1,
+        "iron-gear-wheel": 1
+      },
+      "output": {
+        "burner-inserter": 1
+      }
+    },
+    {
+      "id": "pipe",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "normal": {
+        "time": 0.5,
         "input": {
-            "concrete": 100,
-            "steel-plate": 50,
-            "advanced-circuit": 100,
-            "iron-gear-wheel": 100
+          "iron-plate": 1
         },
         "output": {
-            "centrifuge": 1
+          "pipe": 1
         }
-    }, {
-        "id": "uranium-processing",
+      },
+      "expensive": {
+        "time": 0.5,
+        "input": {
+          "iron-plate": 2
+        },
+        "output": {
+          "pipe": 1
+        }
+      }
+    },
+    {
+      "id": "offshore-pump",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "electronic-circuit": 2,
+        "pipe": 1,
+        "iron-gear-wheel": 1
+      },
+      "output": {
+        "offshore-pump": 1
+      }
+    },
+    {
+      "id": "copper-cable",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "copper-plate": 1
+      },
+      "output": {
+        "copper-cable": 2
+      }
+    },
+    {
+      "id": "small-electric-pole",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "wood": 2,
+        "copper-cable": 2
+      },
+      "output": {
+        "small-electric-pole": 2
+      }
+    },
+    {
+      "id": "pistol",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 5,
+      "input": {
+        "copper-plate": 5,
+        "iron-plate": 5
+      },
+      "output": {
+        "pistol": 1
+      }
+    },
+    {
+      "id": "submachine-gun",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "normal": {
         "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
         "input": {
-            "uranium-ore": 10
+          "iron-gear-wheel": 10,
+          "copper-plate": 5,
+          "iron-plate": 10
         },
         "output": {
-            "uranium-235": 1,
-            "uranium-238": 1
+          "submachine-gun": 1
         }
-    }, {
-        "id": "kovarex-enrichment-process",
-        "time": 50,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "uranium-235": 40,
-            "uranium-238": 5
-        },
-        "output": {
-            "uranium-235": 41,
-            "uranium-238": 2
-        }
-    }, {
-        "id": "nuclear-fuel-reprocessing",
-        "time": 50,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
-        "input": {
-            "used-up-uranium-fuel-cell": 5
-        },
-        "output": {
-            "uranium-238": 3
-        }
-    }, {
-        "id": "uranium-fuel-cell",
+      },
+      "expensive": {
         "time": 10,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
         "input": {
-            "iron-plate": 10,
-            "uranium-235": 1,
-            "uranium-238": 19
+          "iron-gear-wheel": 15,
+          "copper-plate": 20,
+          "iron-plate": 30
         },
         "output": {
-            "uranium-fuel-cell": 10
+          "submachine-gun": 1
         }
-    }, {
-        "id": "heat-exchanger",
+      }
+    },
+    {
+      "id": "firearm-magazine",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 1,
+      "input": {
+        "iron-plate": 4
+      },
+      "output": {
+        "firearm-magazine": 1
+      }
+    },
+    {
+      "id": "light-armor",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 3,
+      "input": {
+        "iron-plate": 40
+      },
+      "output": {
+        "light-armor": 1
+      }
+    },
+    {
+      "id": "radar",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "electronic-circuit": 5,
+        "iron-gear-wheel": 5,
+        "iron-plate": 10
+      },
+      "output": {
+        "radar": 1
+      }
+    },
+    {
+      "id": "small-lamp",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "electronic-circuit": 1,
+        "iron-stick": 3,
+        "iron-plate": 1
+      },
+      "output": {
+        "small-lamp": 1
+      }
+    },
+    {
+      "id": "pipe-to-ground",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "pipe": 10,
+        "iron-plate": 5
+      },
+      "output": {
+        "pipe-to-ground": 2
+      }
+    },
+    {
+      "id": "assembling-machine-1",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "electronic-circuit": 3,
+        "iron-gear-wheel": 5,
+        "iron-plate": 9
+      },
+      "output": {
+        "assembling-machine-1": 1
+      }
+    },
+    {
+      "id": "repair-pack",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "electronic-circuit": 2,
+        "iron-gear-wheel": 2
+      },
+      "output": {
+        "repair-pack": 1
+      }
+    },
+    {
+      "id": "gun-turret",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 8,
+      "input": {
+        "iron-gear-wheel": 10,
+        "copper-plate": 10,
+        "iron-plate": 20
+      },
+      "output": {
+        "gun-turret": 1
+      }
+    },
+    {
+      "id": "night-vision-equipment",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "advanced-circuit": 5,
+        "steel-plate": 10
+      },
+      "output": {
+        "night-vision-equipment": 1
+      }
+    },
+    {
+      "id": "energy-shield-equipment",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "advanced-circuit": 5,
+        "steel-plate": 10
+      },
+      "output": {
+        "energy-shield-equipment": 1
+      }
+    },
+    {
+      "id": "energy-shield-mk2-equipment",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "energy-shield-equipment": 10,
+        "processing-unit": 10
+      },
+      "output": {
+        "energy-shield-mk2-equipment": 1
+      }
+    },
+    {
+      "id": "battery-equipment",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "battery": 5,
+        "steel-plate": 10
+      },
+      "output": {
+        "battery-equipment": 1
+      }
+    },
+    {
+      "id": "battery-mk2-equipment",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "battery-equipment": 10,
+        "processing-unit": 20
+      },
+      "output": {
+        "battery-mk2-equipment": 1
+      }
+    },
+    {
+      "id": "solar-panel-equipment",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "solar-panel": 5,
+        "advanced-circuit": 1,
+        "steel-plate": 5
+      },
+      "output": {
+        "solar-panel-equipment": 1
+      }
+    },
+    {
+      "id": "fusion-reactor-equipment",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "processing-unit": 250
+      },
+      "output": {
+        "fusion-reactor-equipment": 1
+      }
+    },
+    {
+      "id": "personal-laser-defense-equipment",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "processing-unit": 1,
+        "steel-plate": 5,
+        "laser-turret": 5
+      },
+      "output": {
+        "personal-laser-defense-equipment": 1
+      }
+    },
+    {
+      "id": "discharge-defense-equipment",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "processing-unit": 5,
+        "steel-plate": 20,
+        "laser-turret": 10
+      },
+      "output": {
+        "discharge-defense-equipment": 1
+      }
+    },
+    {
+      "id": "exoskeleton-equipment",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "processing-unit": 10,
+        "electric-engine-unit": 30,
+        "steel-plate": 20
+      },
+      "output": {
+        "exoskeleton-equipment": 1
+      }
+    },
+    {
+      "id": "personal-roboport-equipment",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "advanced-circuit": 10,
+        "iron-gear-wheel": 40,
+        "steel-plate": 20,
+        "battery": 45
+      },
+      "output": {
+        "personal-roboport-equipment": 1
+      }
+    },
+    {
+      "id": "personal-roboport-mk2-equipment",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 20,
+      "input": {
+        "personal-roboport-equipment": 5,
+        "processing-unit": 100
+      },
+      "output": {
+        "personal-roboport-mk2-equipment": 1
+      }
+    },
+    {
+      "id": "basic-oil-processing",
+      "building": [
+        "oil-refinery"
+      ],
+      "time": 5,
+      "input": {
+        "crude-oil": 100
+      },
+      "output": {
+        "heavy-oil": 30,
+        "light-oil": 30,
+        "petroleum-gas": 40
+      }
+    },
+    {
+      "id": "advanced-oil-processing",
+      "building": [
+        "oil-refinery"
+      ],
+      "time": 5,
+      "input": {
+        "water": 50,
+        "crude-oil": 100
+      },
+      "output": {
+        "heavy-oil": 10,
+        "light-oil": 45,
+        "petroleum-gas": 55
+      }
+    },
+    {
+      "id": "coal-liquefaction",
+      "building": [
+        "oil-refinery"
+      ],
+      "time": 5,
+      "input": {
+        "coal": 10,
+        "heavy-oil": 25,
+        "steam": 50
+      },
+      "output": {
+        "heavy-oil": 35,
+        "light-oil": 15,
+        "petroleum-gas": 20
+      }
+    },
+    {
+      "id": "heavy-oil-cracking",
+      "building": [
+        "chemical-plant"
+      ],
+      "time": 3,
+      "input": {
+        "water": 30,
+        "heavy-oil": 40
+      },
+      "output": {
+        "light-oil": 30
+      }
+    },
+    {
+      "id": "light-oil-cracking",
+      "building": [
+        "chemical-plant"
+      ],
+      "time": 3,
+      "input": {
+        "water": 30,
+        "light-oil": 30
+      },
+      "output": {
+        "petroleum-gas": 20
+      }
+    },
+    {
+      "id": "sulfuric-acid",
+      "building": [
+        "chemical-plant"
+      ],
+      "time": 1,
+      "input": {
+        "sulfur": 5,
+        "iron-plate": 1,
+        "water": 100
+      },
+      "output": {
+        "sulfuric-acid": 50
+      }
+    },
+    {
+      "id": "plastic-bar",
+      "building": [
+        "chemical-plant"
+      ],
+      "time": 1,
+      "input": {
+        "petroleum-gas": 20,
+        "coal": 1
+      },
+      "output": {
+        "plastic-bar": 2
+      }
+    },
+    {
+      "id": "solid-fuel-from-light-oil",
+      "building": [
+        "chemical-plant"
+      ],
+      "time": 3,
+      "input": {
+        "light-oil": 10
+      },
+      "output": {
+        "solid-fuel": 1
+      }
+    },
+    {
+      "id": "solid-fuel-from-petroleum-gas",
+      "building": [
+        "chemical-plant"
+      ],
+      "time": 3,
+      "input": {
+        "petroleum-gas": 20
+      },
+      "output": {
+        "solid-fuel": 1
+      }
+    },
+    {
+      "id": "solid-fuel-from-heavy-oil",
+      "building": [
+        "chemical-plant"
+      ],
+      "time": 3,
+      "input": {
+        "heavy-oil": 20
+      },
+      "output": {
+        "solid-fuel": 1
+      }
+    },
+    {
+      "id": "sulfur",
+      "building": [
+        "chemical-plant"
+      ],
+      "time": 1,
+      "input": {
+        "water": 30,
+        "petroleum-gas": 30
+      },
+      "output": {
+        "sulfur": 2
+      }
+    },
+    {
+      "id": "lubricant",
+      "building": [
+        "chemical-plant"
+      ],
+      "time": 1,
+      "input": {
+        "heavy-oil": 10
+      },
+      "output": {
+        "lubricant": 10
+      }
+    },
+    {
+      "id": "empty-barrel",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 1,
+      "input": {
+        "steel-plate": 1
+      },
+      "output": {
+        "empty-barrel": 1
+      }
+    },
+    {
+      "id": "steel-plate",
+      "building": [
+        "electric-furnace",
+        "steel-furnace",
+        "stone-furnace"
+      ],
+      "normal": {
+        "time": 17.5,
+        "input": {
+          "iron-plate": 5
+        },
+        "output": {
+          "steel-plate": 1
+        }
+      },
+      "expensive": {
+        "time": 35,
+        "input": {
+          "iron-plate": 10
+        },
+        "output": {
+          "steel-plate": 1
+        }
+      }
+    },
+    {
+      "id": "long-handed-inserter",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "iron-gear-wheel": 1,
+        "iron-plate": 1,
+        "inserter": 1
+      },
+      "output": {
+        "long-handed-inserter": 1
+      }
+    },
+    {
+      "id": "fast-inserter",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "electronic-circuit": 2,
+        "iron-plate": 2,
+        "inserter": 1
+      },
+      "output": {
+        "fast-inserter": 1
+      }
+    },
+    {
+      "id": "filter-inserter",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "fast-inserter": 1,
+        "electronic-circuit": 4
+      },
+      "output": {
+        "filter-inserter": 1
+      }
+    },
+    {
+      "id": "stack-inserter",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "iron-gear-wheel": 15,
+        "electronic-circuit": 15,
+        "advanced-circuit": 1,
+        "fast-inserter": 1
+      },
+      "output": {
+        "stack-inserter": 1
+      }
+    },
+    {
+      "id": "stack-filter-inserter",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "stack-inserter": 1,
+        "electronic-circuit": 5
+      },
+      "output": {
+        "stack-filter-inserter": 1
+      }
+    },
+    {
+      "id": "speed-module",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 15,
+      "input": {
+        "advanced-circuit": 5,
+        "electronic-circuit": 5
+      },
+      "output": {
+        "speed-module": 1
+      }
+    },
+    {
+      "id": "speed-module-2",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 30,
+      "input": {
+        "speed-module": 4,
+        "advanced-circuit": 5,
+        "processing-unit": 5
+      },
+      "output": {
+        "speed-module-2": 1
+      }
+    },
+    {
+      "id": "speed-module-3",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 60,
+      "input": {
+        "speed-module-2": 5,
+        "advanced-circuit": 5,
+        "processing-unit": 5
+      },
+      "output": {
+        "speed-module-3": 1
+      }
+    },
+    {
+      "id": "productivity-module",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 15,
+      "input": {
+        "advanced-circuit": 5,
+        "electronic-circuit": 5
+      },
+      "output": {
+        "productivity-module": 1
+      }
+    },
+    {
+      "id": "productivity-module-2",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 30,
+      "input": {
+        "productivity-module": 4,
+        "advanced-circuit": 5,
+        "processing-unit": 5
+      },
+      "output": {
+        "productivity-module-2": 1
+      }
+    },
+    {
+      "id": "productivity-module-3",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 60,
+      "input": {
+        "productivity-module-2": 5,
+        "advanced-circuit": 5,
+        "processing-unit": 5
+      },
+      "output": {
+        "productivity-module-3": 1
+      }
+    },
+    {
+      "id": "effectivity-module",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 15,
+      "input": {
+        "advanced-circuit": 5,
+        "electronic-circuit": 5
+      },
+      "output": {
+        "effectivity-module": 1
+      }
+    },
+    {
+      "id": "effectivity-module-2",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 30,
+      "input": {
+        "effectivity-module": 4,
+        "advanced-circuit": 5,
+        "processing-unit": 5
+      },
+      "output": {
+        "effectivity-module-2": 1
+      }
+    },
+    {
+      "id": "effectivity-module-3",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 60,
+      "input": {
+        "effectivity-module-2": 5,
+        "advanced-circuit": 5,
+        "processing-unit": 5
+      },
+      "output": {
+        "effectivity-module-3": 1
+      }
+    },
+    {
+      "id": "player-port",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "electronic-circuit": 10,
+        "iron-gear-wheel": 5,
+        "iron-plate": 1
+      },
+      "output": {
+        "player-port": 1
+      }
+    },
+    {
+      "id": "fast-transport-belt",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "iron-gear-wheel": 5,
+        "transport-belt": 1
+      },
+      "output": {
+        "fast-transport-belt": 1
+      }
+    },
+    {
+      "id": "express-transport-belt",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2"
+      ],
+      "normal": {
         "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
         "input": {
-            "steel-plate": 10,
-            "copper-plate": 100,
-            "pipe": 10
+          "iron-gear-wheel": 10,
+          "fast-transport-belt": 1,
+          "lubricant": 20
         },
         "output": {
-            "heat-exchanger": 1
+          "express-transport-belt": 1
         }
-    }, {
-        "id": "heat-pipe",
+      },
+      "expensive": {
         "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
         "input": {
-            "steel-plate": 10,
-            "copper-plate": 20
+          "iron-gear-wheel": 20,
+          "fast-transport-belt": 1,
+          "lubricant": 20
         },
         "output": {
-            "heat-pipe": 1
+          "express-transport-belt": 1
         }
-    }, {
-        "id": "steam-turbine",
+      }
+    },
+    {
+      "id": "solar-panel",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "steel-plate": 5,
+        "electronic-circuit": 15,
+        "copper-plate": 5
+      },
+      "output": {
+        "solar-panel": 1
+      }
+    },
+    {
+      "id": "assembling-machine-2",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "normal": {
         "time": 0.5,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
         "input": {
-            "iron-gear-wheel": 50,
-            "copper-plate": 50,
-            "pipe": 20
+          "iron-plate": 9,
+          "electronic-circuit": 3,
+          "iron-gear-wheel": 5,
+          "assembling-machine-1": 1
         },
         "output": {
-            "steam-turbine": 1
+          "assembling-machine-2": 1
         }
-    }, {
-        "id": "laser-turret",
-        "time": 20,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
+      },
+      "expensive": {
+        "time": 0.5,
         "input": {
-            "steel-plate": 20,
-            "electronic-circuit": 20,
-            "battery": 12
+          "iron-plate": 20,
+          "electronic-circuit": 5,
+          "iron-gear-wheel": 10,
+          "assembling-machine-1": 1
         },
         "output": {
-            "laser-turret": 1
+          "assembling-machine-2": 1
         }
-    }, {
-        "id": "flamethrower-turret",
-        "time": 20,
-        "building": ["assembling-machine-3", "assembling-machine-2", "assembling-machine-1"],
+      }
+    },
+    {
+      "id": "assembling-machine-3",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "speed-module": 4,
+        "assembling-machine-2": 2
+      },
+      "output": {
+        "assembling-machine-3": 1
+      }
+    },
+    {
+      "id": "car",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "engine-unit": 8,
+        "iron-plate": 20,
+        "steel-plate": 5
+      },
+      "output": {
+        "car": 1
+      }
+    },
+    {
+      "id": "tank",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "normal": {
+        "time": 0.5,
         "input": {
-            "steel-plate": 30,
-            "iron-gear-wheel": 15,
-            "pipe": 10,
-            "engine-unit": 5
+          "engine-unit": 32,
+          "steel-plate": 50,
+          "iron-gear-wheel": 15,
+          "advanced-circuit": 10
         },
         "output": {
-            "flamethrower-turret": 1
+          "tank": 1
         }
-    }]
+      },
+      "expensive": {
+        "time": 0.5,
+        "input": {
+          "engine-unit": 64,
+          "steel-plate": 100,
+          "iron-gear-wheel": 30,
+          "advanced-circuit": 20
+        },
+        "output": {
+          "tank": 1
+        }
+      }
+    },
+    {
+      "id": "rail",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "stone": 1,
+        "iron-stick": 1,
+        "steel-plate": 1
+      },
+      "output": {
+        "rail": 2
+      }
+    },
+    {
+      "id": "locomotive",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "engine-unit": 20,
+        "electronic-circuit": 10,
+        "steel-plate": 30
+      },
+      "output": {
+        "locomotive": 1
+      }
+    },
+    {
+      "id": "cargo-wagon",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "iron-gear-wheel": 10,
+        "iron-plate": 20,
+        "steel-plate": 20
+      },
+      "output": {
+        "cargo-wagon": 1
+      }
+    },
+    {
+      "id": "fluid-wagon",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 1.5,
+      "input": {
+        "iron-gear-wheel": 10,
+        "steel-plate": 16,
+        "pipe": 8,
+        "storage-tank": 3
+      },
+      "output": {
+        "fluid-wagon": 1
+      }
+    },
+    {
+      "id": "train-stop",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "electronic-circuit": 5,
+        "iron-plate": 10,
+        "steel-plate": 3
+      },
+      "output": {
+        "train-stop": 1
+      }
+    },
+    {
+      "id": "rail-signal",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "electronic-circuit": 1,
+        "iron-plate": 5
+      },
+      "output": {
+        "rail-signal": 1
+      }
+    },
+    {
+      "id": "rail-chain-signal",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "electronic-circuit": 1,
+        "iron-plate": 5
+      },
+      "output": {
+        "rail-chain-signal": 1
+      }
+    },
+    {
+      "id": "heavy-armor",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 8,
+      "input": {
+        "copper-plate": 100,
+        "steel-plate": 50
+      },
+      "output": {
+        "heavy-armor": 1
+      }
+    },
+    {
+      "id": "modular-armor",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 15,
+      "input": {
+        "advanced-circuit": 30,
+        "steel-plate": 50
+      },
+      "output": {
+        "modular-armor": 1
+      }
+    },
+    {
+      "id": "power-armor",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 20,
+      "input": {
+        "processing-unit": 40,
+        "electric-engine-unit": 20,
+        "steel-plate": 40
+      },
+      "output": {
+        "power-armor": 1
+      }
+    },
+    {
+      "id": "power-armor-mk2",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 25,
+      "input": {
+        "effectivity-module-3": 5,
+        "speed-module-3": 5,
+        "processing-unit": 40,
+        "steel-plate": 40
+      },
+      "output": {
+        "power-armor-mk2": 1
+      }
+    },
+    {
+      "id": "iron-chest",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "iron-plate": 8
+      },
+      "output": {
+        "iron-chest": 1
+      }
+    },
+    {
+      "id": "steel-chest",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "steel-plate": 8
+      },
+      "output": {
+        "steel-chest": 1
+      }
+    },
+    {
+      "id": "stone-wall",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "stone-brick": 5
+      },
+      "output": {
+        "stone-wall": 1
+      }
+    },
+    {
+      "id": "gate",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "stone-wall": 1,
+        "steel-plate": 2,
+        "electronic-circuit": 2
+      },
+      "output": {
+        "gate": 1
+      }
+    },
+    {
+      "id": "flamethrower",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "steel-plate": 5,
+        "iron-gear-wheel": 10
+      },
+      "output": {
+        "flamethrower": 1
+      }
+    },
+    {
+      "id": "land-mine",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 5,
+      "input": {
+        "steel-plate": 1,
+        "explosives": 2
+      },
+      "output": {
+        "land-mine": 4
+      }
+    },
+    {
+      "id": "rocket-launcher",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "iron-plate": 5,
+        "iron-gear-wheel": 5,
+        "electronic-circuit": 5
+      },
+      "output": {
+        "rocket-launcher": 1
+      }
+    },
+    {
+      "id": "shotgun",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "iron-plate": 15,
+        "iron-gear-wheel": 5,
+        "copper-plate": 10,
+        "wood": 5
+      },
+      "output": {
+        "shotgun": 1
+      }
+    },
+    {
+      "id": "combat-shotgun",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "steel-plate": 15,
+        "iron-gear-wheel": 5,
+        "copper-plate": 10,
+        "wood": 10
+      },
+      "output": {
+        "combat-shotgun": 1
+      }
+    },
+    {
+      "id": "railgun",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 8,
+      "input": {
+        "steel-plate": 15,
+        "copper-plate": 15,
+        "electronic-circuit": 10,
+        "advanced-circuit": 5
+      },
+      "output": {
+        "railgun": 1
+      }
+    },
+    {
+      "id": "science-pack-1",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 5,
+      "input": {
+        "copper-plate": 1,
+        "iron-gear-wheel": 1
+      },
+      "output": {
+        "science-pack-1": 1
+      }
+    },
+    {
+      "id": "science-pack-2",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 6,
+      "input": {
+        "inserter": 1,
+        "transport-belt": 1
+      },
+      "output": {
+        "science-pack-2": 1
+      }
+    },
+    {
+      "id": "science-pack-3",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 12,
+      "input": {
+        "advanced-circuit": 1,
+        "engine-unit": 1,
+        "electric-mining-drill": 1
+      },
+      "output": {
+        "science-pack-3": 1
+      }
+    },
+    {
+      "id": "military-science-pack",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "piercing-rounds-magazine": 1,
+        "grenade": 1,
+        "gun-turret": 1
+      },
+      "output": {
+        "military-science-pack": 2
+      }
+    },
+    {
+      "id": "production-science-pack",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 14,
+      "input": {
+        "electric-engine-unit": 1,
+        "assembling-machine-1": 1,
+        "electric-furnace": 1
+      },
+      "output": {
+        "production-science-pack": 2
+      }
+    },
+    {
+      "id": "high-tech-science-pack",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 14,
+      "input": {
+        "battery": 1,
+        "processing-unit": 3,
+        "speed-module": 1,
+        "copper-cable": 30
+      },
+      "output": {
+        "high-tech-science-pack": 2
+      }
+    },
+    {
+      "id": "lab",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 3,
+      "input": {
+        "electronic-circuit": 10,
+        "iron-gear-wheel": 10,
+        "transport-belt": 4
+      },
+      "output": {
+        "lab": 1
+      }
+    },
+    {
+      "id": "red-wire",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "electronic-circuit": 1,
+        "copper-cable": 1
+      },
+      "output": {
+        "red-wire": 1
+      }
+    },
+    {
+      "id": "green-wire",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "electronic-circuit": 1,
+        "copper-cable": 1
+      },
+      "output": {
+        "green-wire": 1
+      }
+    },
+    {
+      "id": "underground-belt",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 1,
+      "input": {
+        "iron-plate": 10,
+        "transport-belt": 5
+      },
+      "output": {
+        "underground-belt": 2
+      }
+    },
+    {
+      "id": "fast-underground-belt",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "iron-gear-wheel": 40,
+        "underground-belt": 2
+      },
+      "output": {
+        "fast-underground-belt": 2
+      }
+    },
+    {
+      "id": "express-underground-belt",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2"
+      ],
+      "time": 0.5,
+      "input": {
+        "iron-gear-wheel": 80,
+        "fast-underground-belt": 2,
+        "lubricant": 40
+      },
+      "output": {
+        "express-underground-belt": 2
+      }
+    },
+    {
+      "id": "loader",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 1,
+      "input": {
+        "inserter": 5,
+        "electronic-circuit": 5,
+        "iron-gear-wheel": 5,
+        "iron-plate": 5,
+        "transport-belt": 5
+      },
+      "output": {
+        "loader": 1
+      }
+    },
+    {
+      "id": "fast-loader",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 3,
+      "input": {
+        "fast-transport-belt": 5,
+        "loader": 1
+      },
+      "output": {
+        "fast-loader": 1
+      }
+    },
+    {
+      "id": "express-loader",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "express-transport-belt": 5,
+        "fast-loader": 1
+      },
+      "output": {
+        "express-loader": 1
+      }
+    },
+    {
+      "id": "splitter",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 1,
+      "input": {
+        "electronic-circuit": 5,
+        "iron-plate": 5,
+        "transport-belt": 4
+      },
+      "output": {
+        "splitter": 1
+      }
+    },
+    {
+      "id": "fast-splitter",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 2,
+      "input": {
+        "splitter": 1,
+        "iron-gear-wheel": 10,
+        "electronic-circuit": 10
+      },
+      "output": {
+        "fast-splitter": 1
+      }
+    },
+    {
+      "id": "express-splitter",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2"
+      ],
+      "time": 2,
+      "input": {
+        "fast-splitter": 1,
+        "iron-gear-wheel": 10,
+        "advanced-circuit": 10,
+        "lubricant": 80
+      },
+      "output": {
+        "express-splitter": 1
+      }
+    },
+    {
+      "id": "advanced-circuit",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "normal": {
+        "time": 6,
+        "input": {
+          "electronic-circuit": 2,
+          "plastic-bar": 2,
+          "copper-cable": 4
+        },
+        "output": {
+          "advanced-circuit": 1
+        }
+      },
+      "expensive": {
+        "time": 6,
+        "input": {
+          "electronic-circuit": 2,
+          "plastic-bar": 4,
+          "copper-cable": 8
+        },
+        "output": {
+          "advanced-circuit": 1
+        }
+      }
+    },
+    {
+      "id": "processing-unit",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2"
+      ],
+      "normal": {
+        "time": 10,
+        "input": {
+          "electronic-circuit": 20,
+          "advanced-circuit": 2,
+          "sulfuric-acid": 5
+        },
+        "output": {
+          "processing-unit": 1
+        }
+      },
+      "expensive": {
+        "time": 10,
+        "input": {
+          "electronic-circuit": 20,
+          "advanced-circuit": 2,
+          "sulfuric-acid": 10
+        },
+        "output": {
+          "processing-unit": 1
+        }
+      }
+    },
+    {
+      "id": "logistic-robot",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "flying-robot-frame": 1,
+        "advanced-circuit": 2
+      },
+      "output": {
+        "logistic-robot": 1
+      }
+    },
+    {
+      "id": "construction-robot",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "flying-robot-frame": 1,
+        "electronic-circuit": 2
+      },
+      "output": {
+        "construction-robot": 1
+      }
+    },
+    {
+      "id": "logistic-chest-passive-provider",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "steel-chest": 1,
+        "electronic-circuit": 3,
+        "advanced-circuit": 1
+      },
+      "output": {
+        "logistic-chest-passive-provider": 1
+      }
+    },
+    {
+      "id": "logistic-chest-active-provider",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "steel-chest": 1,
+        "electronic-circuit": 3,
+        "advanced-circuit": 1
+      },
+      "output": {
+        "logistic-chest-active-provider": 1
+      }
+    },
+    {
+      "id": "logistic-chest-storage",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "steel-chest": 1,
+        "electronic-circuit": 3,
+        "advanced-circuit": 1
+      },
+      "output": {
+        "logistic-chest-storage": 1
+      }
+    },
+    {
+      "id": "logistic-chest-requester",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "steel-chest": 1,
+        "electronic-circuit": 3,
+        "advanced-circuit": 1
+      },
+      "output": {
+        "logistic-chest-requester": 1
+      }
+    },
+    {
+      "id": "rocket-silo",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 30,
+      "input": {
+        "steel-plate": 1000,
+        "concrete": 1000,
+        "pipe": 100,
+        "processing-unit": 200,
+        "electric-engine-unit": 200
+      },
+      "output": {
+        "rocket-silo": 1
+      }
+    },
+    {
+      "id": "roboport",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "steel-plate": 45,
+        "iron-gear-wheel": 45,
+        "advanced-circuit": 45
+      },
+      "output": {
+        "roboport": 1
+      }
+    },
+    {
+      "id": "steel-axe",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "steel-plate": 5,
+        "iron-stick": 2
+      },
+      "output": {
+        "steel-axe": 1
+      }
+    },
+    {
+      "id": "big-electric-pole",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "steel-plate": 5,
+        "copper-plate": 5
+      },
+      "output": {
+        "big-electric-pole": 1
+      }
+    },
+    {
+      "id": "substation",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "steel-plate": 10,
+        "advanced-circuit": 5,
+        "copper-plate": 5
+      },
+      "output": {
+        "substation": 1
+      }
+    },
+    {
+      "id": "medium-electric-pole",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "steel-plate": 2,
+        "copper-plate": 2
+      },
+      "output": {
+        "medium-electric-pole": 1
+      }
+    },
+    {
+      "id": "accumulator",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "iron-plate": 2,
+        "battery": 5
+      },
+      "output": {
+        "accumulator": 1
+      }
+    },
+    {
+      "id": "steel-furnace",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 3,
+      "input": {
+        "steel-plate": 6,
+        "stone-brick": 10
+      },
+      "output": {
+        "steel-furnace": 1
+      }
+    },
+    {
+      "id": "electric-furnace",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 5,
+      "input": {
+        "steel-plate": 10,
+        "advanced-circuit": 5,
+        "stone-brick": 10
+      },
+      "output": {
+        "electric-furnace": 1
+      }
+    },
+    {
+      "id": "beacon",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 15,
+      "input": {
+        "electronic-circuit": 20,
+        "advanced-circuit": 20,
+        "steel-plate": 10,
+        "copper-cable": 10
+      },
+      "output": {
+        "beacon": 1
+      }
+    },
+    {
+      "id": "pumpjack",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 5,
+      "input": {
+        "steel-plate": 5,
+        "iron-gear-wheel": 10,
+        "electronic-circuit": 5,
+        "pipe": 10
+      },
+      "output": {
+        "pumpjack": 1
+      }
+    },
+    {
+      "id": "oil-refinery",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "steel-plate": 15,
+        "iron-gear-wheel": 10,
+        "stone-brick": 10,
+        "electronic-circuit": 10,
+        "pipe": 10
+      },
+      "output": {
+        "oil-refinery": 1
+      }
+    },
+    {
+      "id": "engine-unit",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "steel-plate": 1,
+        "iron-gear-wheel": 1,
+        "pipe": 2
+      },
+      "output": {
+        "engine-unit": 1
+      }
+    },
+    {
+      "id": "electric-engine-unit",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2"
+      ],
+      "time": 10,
+      "input": {
+        "engine-unit": 1,
+        "lubricant": 15,
+        "electronic-circuit": 2
+      },
+      "output": {
+        "electric-engine-unit": 1
+      }
+    },
+    {
+      "id": "flying-robot-frame",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 20,
+      "input": {
+        "electric-engine-unit": 1,
+        "battery": 2,
+        "steel-plate": 1,
+        "electronic-circuit": 3
+      },
+      "output": {
+        "flying-robot-frame": 1
+      }
+    },
+    {
+      "id": "explosives",
+      "building": [
+        "chemical-plant"
+      ],
+      "normal": {
+        "time": 5,
+        "input": {
+          "sulfur": 1,
+          "coal": 1,
+          "water": 10
+        },
+        "output": {
+          "explosives": 1
+        }
+      },
+      "expensive": {
+        "time": 5,
+        "input": {
+          "sulfur": 2,
+          "coal": 2,
+          "water": 10
+        },
+        "output": {
+          "explosives": 1
+        }
+      }
+    },
+    {
+      "id": "battery",
+      "building": [
+        "chemical-plant"
+      ],
+      "normal": {
+        "time": 5,
+        "input": {
+          "sulfuric-acid": 20,
+          "iron-plate": 1,
+          "copper-plate": 1
+        },
+        "output": {
+          "battery": 1
+        }
+      },
+      "expensive": {
+        "time": 5,
+        "input": {
+          "sulfuric-acid": 40,
+          "iron-plate": 1,
+          "copper-plate": 1
+        },
+        "output": {
+          "battery": 1
+        }
+      }
+    },
+    {
+      "id": "storage-tank",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 3,
+      "input": {
+        "iron-plate": 20,
+        "steel-plate": 5
+      },
+      "output": {
+        "storage-tank": 1
+      }
+    },
+    {
+      "id": "pump",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 2,
+      "input": {
+        "engine-unit": 1,
+        "steel-plate": 1,
+        "pipe": 1
+      },
+      "output": {
+        "pump": 1
+      }
+    },
+    {
+      "id": "chemical-plant",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 5,
+      "input": {
+        "steel-plate": 5,
+        "iron-gear-wheel": 5,
+        "electronic-circuit": 5,
+        "pipe": 5
+      },
+      "output": {
+        "chemical-plant": 1
+      }
+    },
+    {
+      "id": "small-plane",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 30,
+      "input": {
+        "plastic-bar": 100,
+        "advanced-circuit": 200,
+        "electric-engine-unit": 20,
+        "battery": 100
+      },
+      "output": {
+        "small-plane": 1
+      }
+    },
+    {
+      "id": "arithmetic-combinator",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "copper-cable": 5,
+        "electronic-circuit": 5
+      },
+      "output": {
+        "arithmetic-combinator": 1
+      }
+    },
+    {
+      "id": "decider-combinator",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "copper-cable": 5,
+        "electronic-circuit": 5
+      },
+      "output": {
+        "decider-combinator": 1
+      }
+    },
+    {
+      "id": "constant-combinator",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "copper-cable": 5,
+        "electronic-circuit": 2
+      },
+      "output": {
+        "constant-combinator": 1
+      }
+    },
+    {
+      "id": "power-switch",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 2,
+      "input": {
+        "iron-plate": 5,
+        "copper-cable": 5,
+        "electronic-circuit": 2
+      },
+      "output": {
+        "power-switch": 1
+      }
+    },
+    {
+      "id": "programmable-speaker",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 2,
+      "input": {
+        "iron-plate": 5,
+        "copper-cable": 5,
+        "electronic-circuit": 4
+      },
+      "output": {
+        "programmable-speaker": 1
+      }
+    },
+    {
+      "id": "low-density-structure",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "normal": {
+        "time": 30,
+        "input": {
+          "steel-plate": 10,
+          "copper-plate": 5,
+          "plastic-bar": 5
+        },
+        "output": {
+          "low-density-structure": 1
+        }
+      },
+      "expensive": {
+        "time": 30,
+        "input": {
+          "steel-plate": 10,
+          "copper-plate": 10,
+          "plastic-bar": 10
+        },
+        "output": {
+          "low-density-structure": 1
+        }
+      }
+    },
+    {
+      "id": "rocket-fuel",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 30,
+      "input": {
+        "solid-fuel": 10
+      },
+      "output": {
+        "rocket-fuel": 1
+      }
+    },
+    {
+      "id": "rocket-control-unit",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 30,
+      "input": {
+        "processing-unit": 1,
+        "speed-module": 1
+      },
+      "output": {
+        "rocket-control-unit": 1
+      }
+    },
+    {
+      "id": "rocket-part",
+      "building": [
+        "rocket-silo"
+      ],
+      "time": 3,
+      "input": {
+        "low-density-structure": 10,
+        "rocket-fuel": 10,
+        "rocket-control-unit": 10
+      },
+      "output": {
+        "rocket-part": 1
+      }
+    },
+    {
+      "id": "satellite",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 3,
+      "input": {
+        "low-density-structure": 100,
+        "solar-panel": 100,
+        "accumulator": 100,
+        "radar": 5,
+        "processing-unit": 100,
+        "rocket-fuel": 50
+      },
+      "output": {
+        "satellite": 1
+      }
+    },
+    {
+      "id": "concrete",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2"
+      ],
+      "time": 10,
+      "input": {
+        "stone-brick": 5,
+        "iron-ore": 1,
+        "water": 100
+      },
+      "output": {
+        "concrete": 10
+      }
+    },
+    {
+      "id": "hazard-concrete",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.25,
+      "input": {
+        "concrete": 10
+      },
+      "output": {
+        "hazard-concrete": 10
+      }
+    },
+    {
+      "id": "landfill",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "stone": 20
+      },
+      "output": {
+        "landfill": 1
+      }
+    },
+    {
+      "id": "electric-energy-interface",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "iron-plate": 2,
+        "electronic-circuit": 5
+      },
+      "output": {
+        "electric-energy-interface": 1
+      }
+    },
+    {
+      "id": "nuclear-reactor",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 4,
+      "input": {
+        "concrete": 500,
+        "steel-plate": 500,
+        "advanced-circuit": 500,
+        "copper-plate": 500
+      },
+      "output": {
+        "nuclear-reactor": 1
+      }
+    },
+    {
+      "id": "centrifuge",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 4,
+      "input": {
+        "concrete": 100,
+        "steel-plate": 50,
+        "advanced-circuit": 100,
+        "iron-gear-wheel": 100
+      },
+      "output": {
+        "centrifuge": 1
+      }
+    },
+    {
+      "id": "uranium-processing",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "uranium-ore": 10
+      },
+      "output": {
+        "uranium-235": 1,
+        "uranium-238": 1
+      }
+    },
+    {
+      "id": "kovarex-enrichment-process",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 50,
+      "input": {
+        "uranium-235": 40,
+        "uranium-238": 5
+      },
+      "output": {
+        "uranium-235": 41,
+        "uranium-238": 2
+      }
+    },
+    {
+      "id": "nuclear-fuel-reprocessing",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 50,
+      "input": {
+        "used-up-uranium-fuel-cell": 5
+      },
+      "output": {
+        "uranium-238": 3
+      }
+    },
+    {
+      "id": "uranium-fuel-cell",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 10,
+      "input": {
+        "iron-plate": 10,
+        "uranium-235": 1,
+        "uranium-238": 19
+      },
+      "output": {
+        "uranium-fuel-cell": 10
+      }
+    },
+    {
+      "id": "heat-exchanger",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "steel-plate": 10,
+        "copper-plate": 100,
+        "pipe": 10
+      },
+      "output": {
+        "heat-exchanger": 1
+      }
+    },
+    {
+      "id": "heat-pipe",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "steel-plate": 10,
+        "copper-plate": 20
+      },
+      "output": {
+        "heat-pipe": 1
+      }
+    },
+    {
+      "id": "steam-turbine",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 0.5,
+      "input": {
+        "iron-gear-wheel": 50,
+        "copper-plate": 50,
+        "pipe": 20
+      },
+      "output": {
+        "steam-turbine": 1
+      }
+    },
+    {
+      "id": "laser-turret",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 20,
+      "input": {
+        "steel-plate": 20,
+        "electronic-circuit": 20,
+        "battery": 12
+      },
+      "output": {
+        "laser-turret": 1
+      }
+    },
+    {
+      "id": "flamethrower-turret",
+      "building": [
+        "assembling-machine-3",
+        "assembling-machine-2",
+        "assembling-machine-1"
+      ],
+      "time": 20,
+      "input": {
+        "steel-plate": 30,
+        "iron-gear-wheel": 15,
+        "pipe": 10,
+        "engine-unit": 5
+      },
+      "output": {
+        "flamethrower-turret": 1
+      }
+    }
+  ]
 }

--- a/src/app/dataLoader.js
+++ b/src/app/dataLoader.js
@@ -8,7 +8,7 @@ define(['knockout', 'jquery', 'app/LoadManager'], function(ko, $, Manager) {
         manager.mapOutput = {};
         for (var r = 0, lenR = recipes.length; r < lenR; r++) {
 
-            var recipeOutput = Object.keys(recipes[r].output);
+            var recipeOutput = Object.keys(!!recipes[r].output ? recipes[r].output : recipes[r].normal.output);
             for (var o = 0, lenO = recipeOutput.length; o < lenO; o++) {
                 var output = recipeOutput[o];
                 if (!manager.mapOutput[output]) {

--- a/src/app/formulae.js
+++ b/src/app/formulae.js
@@ -1,4 +1,4 @@
-define([], function() {
+define(['app/recipes'], function($r) {
 
     function getValue(load, property) {
         //  using bit OR (value | 0) to parse to number is causing the decimal to be lost
@@ -93,28 +93,31 @@ define([], function() {
         return calculateTotal(selectedBuilding(), multiplier, 'speed');
     }
 
-    function validateRecipe(selectedRecipe, selectedBuilding, loop, action) {
+    function validateRecipe(selectedRecipe, selectedBuilding, loop, expensiveRecipes, action) {
         var recipe = typeof(selectedRecipe) === "function" ? selectedRecipe() : selectedRecipe;
         var building = typeof(selectedBuilding) === "function" ? selectedBuilding() : selectedBuilding;
+        var expensiveRecipes = typeof(expensiveRecipes) === "function" ? expensiveRecipes() : expensiveRecipes;
         var result = {};
+        var items = loop === "input" ? $r.GetRecipeInput(recipe, expensiveRecipes) : $r.GetRecipeOutput(recipe, expensiveRecipes);
         if (recipe) {
-            var time = recipe.time;
-            for (var i in recipe[loop]) {
-                result[i] = action(building, recipe[loop][i], time);
+            //TODO time not based on marathon
+            var time = $r.GetRecipeTime(recipe, expensiveRecipes);
+            for (var i in items) {
+                result[i] = action(building, items[i], time);
             }
         }
         return result;
     }
 
-    function _getPerSecondInputRecipes(selectedRecipe, selectedBuilding, modifiedSpeed) {
-        return validateRecipe(selectedRecipe, selectedBuilding, 'input', function(building, value, time) {
+    function _getPerSecondInputRecipes(selectedRecipe, selectedBuilding, modifiedSpeed, expensiveRecipes) {
+        return validateRecipe(selectedRecipe, selectedBuilding, 'input', expensiveRecipes, function(building, value, time) {
             var speed = (building ? building.speed : 1) * (1 + modifiedSpeed);
             return value / (time / speed);
         });
     }
 
-    function _getPerSecondOutputRecipes(selectedRecipe, selectedBuilding, modifiedSpeed, modifiedProduction) {
-        return validateRecipe(selectedRecipe, selectedBuilding, 'output', function(building, value, time) {
+    function _getPerSecondOutputRecipes(selectedRecipe, selectedBuilding, modifiedSpeed, modifiedProduction, expensiveRecipes) {
+        return validateRecipe(selectedRecipe, selectedBuilding, 'output', expensiveRecipes, function(building, value, time) {
             var speed = (building ? building.speed : 1) * (1 + modifiedSpeed);
             var production = (building ? building.production : 1) * (1 + modifiedProduction)
             var isMiningDrill = (building ? building.canMine : 0);

--- a/src/components/calculator-page/calculator.html
+++ b/src/components/calculator-page/calculator.html
@@ -10,9 +10,16 @@
             </button>
         </div>
 
-        <div class="col-sm-11">
+        <div class="col-sm-8">
             <label class="form-control-label">Cycle length ( in seconds )</label>
             <input data-bind="value:cycleLength" class="form-control" type="number" min="1" />
+        </div>
+        <div class="col-sm-3">
+        <div class="checkbox">
+            <label>
+              <input data-bind="checked:expensiveRecipes" type="checkbox"> Marathon recipes
+            </label>
+        </div>
         </div>
     </div>
 
@@ -25,7 +32,7 @@
         </section>
         
         <selection-recipe class="row" params="{ 
-            selectedRecipe: selectedRecipe, selectedModules: selectedModules }">
+            selectedRecipe: selectedRecipe, selectedModules: selectedModules, expensiveRecipes: expensiveRecipes }">
         </selection-recipe>
         <selection-building class="row" params="{ 
             numberOfBuildings: numberOfBuildings, selectedBuilding: selectedBuilding, selectedRecipe: selectedRecipe, selectedModules: selectedModules }">
@@ -34,7 +41,7 @@
             <statistic-view class="col-lg-6" params="{
                 selectedBuilding: selectedBuilding, selectedRecipe:selectedRecipe, selectedModules:selectedModules,
                 calculateCycle:calculateCycle, cycleLength:cycleLength, 
-                calculateBuildings:calculateBuildings, numberOfBuildings:numberOfBuildings }">
+                calculateBuildings:calculateBuildings, numberOfBuildings:numberOfBuildings, expensiveRecipes: expensiveRecipes }">
             </statistic-view>
             <selection-module class="col-lg-6" params="{ selectedModules: selectedModules }"></selection-module>
         </section>
@@ -44,5 +51,5 @@
 <production-table class="container-fluid" data-bind="visible:recipeTree().length>0" params="{
     recipeTree:recipeTree, numberOfBuildings:numberOfBuildings, 
     calculateCycle:calculateCycle, cycleLength:cycleLength, calculateBuildings:calculateBuildings,
-    removeRecipeClick:removeRecipe(), includeChildrenClick: includeChildren()}">
+    removeRecipeClick:removeRecipe(), includeChildrenClick: includeChildren(), expensiveRecipes: expensiveRecipes}">
 </production-table>

--- a/src/components/calculator-page/calculator.js
+++ b/src/components/calculator-page/calculator.js
@@ -1,4 +1,4 @@
-define(['knockout', 'text!./calculator.html', 'data', /*pre-load*/ 'components/production/production-row'], function(ko, template, dataLoader) {
+define(['knockout', 'text!./calculator.html', 'data', 'app/recipes', /*pre-load*/ 'components/production/production-row'], function(ko, template, dataLoader, $r) {
 
     function CalculatorViewModel(route) {
         var $self = this;
@@ -10,6 +10,7 @@ define(['knockout', 'text!./calculator.html', 'data', /*pre-load*/ 'components/p
         $self.cycleLength = ko.observable(1);
         $self.numberOfBuildings = ko.observable(1);
 
+        $self.expensiveRecipes = ko.observable(false);
         $self.selectedRecipe = ko.observable();
         $self.selectedBuilding = ko.observable();
         $self.selectedModules = dataLoader.modules;
@@ -52,7 +53,7 @@ define(['knockout', 'text!./calculator.html', 'data', /*pre-load*/ 'components/p
         var $self = this;
         return recipeViewModel => {
 
-            var inputs = _loadInputs(1, recipeViewModel.recipe);
+            var inputs = _loadInputs(1, recipeViewModel.recipe, $self.expensiveRecipes());
             var children = recipeViewModel.children.peek();
 
             for (var i in inputs) {
@@ -74,10 +75,10 @@ define(['knockout', 'text!./calculator.html', 'data', /*pre-load*/ 'components/p
         this.isOpen(!this.isOpen());
     }
 
-    function _loadInputs(length, recipe) {
+    function _loadInputs(length, recipe, expensiveRecipes) {
         var result = [];
         if (length > 0) {
-            for (var i = 0, keys = Object.keys(recipe.input); i < keys.length; i++) {
+            for (var i = 0, keys = Object.keys($r.GetRecipeInput(recipe, expensiveRecipes)); i < keys.length; i++) {
                 var input = keys[i];
 
                 var recipeByOutput = dataLoader.recipes.getByOutput(input);

--- a/src/components/database-page/database.js
+++ b/src/components/database-page/database.js
@@ -47,6 +47,35 @@ define(['knockout', 'text!./database.html', 'jquery',
         'oil-processing': ['oil-refinery'],
         'smelting': ['electric-furnace', 'steel-furnace', 'stone-furnace']
     }
+    
+    var intermediate_products = {
+        'wood': 1,
+        'iron-plate': 1,
+        'copper-plate': 1,
+        'steel-plate': 1,
+        'stone-brick': 1,
+        'sulfur': 1,
+        'plastic-bar': 1,
+        'battery': 1,
+        'iron-stick': 1,
+        'iron-gear-wheel': 1,
+        'copper-cable': 1,
+        'eletronic-circuit': 1,
+        'advanced-circuit': 1,
+        'processing-unit': 1,
+        'engine-unit': 1,
+        'flying-robot-frame': 1,
+        'science-pack-1': 1,
+        'science-pack-2': 1,
+        'science-pack-3': 1,
+        'military-science-pack': 1,
+        'production-science-pack': 1,
+        'high-tech-science-pack': 1,
+        'space-science-pack': 1,
+        'empty-barrel': 1,
+        'explosives': 1
+    };
+
     DatabaseViewModel.prototype.parseData = function(file) {
         var text = luaToJson(file || this.file_content());
         var data = eval(text);
@@ -59,13 +88,15 @@ define(['knockout', 'text!./database.html', 'jquery',
                 result.push({
                     id: dataitem.name,
                     building: building_map[dataitem.category] || building_map["crafting"],
+                    accept_productivity: !!intermediate_products[dataitem.name],
                     normal: parseDifficulty(dataitem.normal),
                     expensive: parseDifficulty(dataitem.expensive)
                 });
             } else {
                 result.push($.extend({
                         id: dataitem.name,
-                        building: building_map[dataitem.category] || building_map["crafting"]
+                        building: building_map[dataitem.category] || building_map["crafting"],
+                        accept_productivity: !!intermediate_products[dataitem.name]
                     }                    
                     ,parseDifficulty(dataitem)
                 ));

--- a/src/components/database-page/database.js
+++ b/src/components/database-page/database.js
@@ -40,6 +40,8 @@ define(['knockout', 'text!./database.html', 'jquery',
     }
 
     var building_map = {
+        'crafting-with-fluid': ['assembling-machine-3', 'assembling-machine-2'],
+        'rocket-building': ['rocket-silo'],
         'crafting': ['assembling-machine-3', 'assembling-machine-2', 'assembling-machine-1'],
         'chemistry': ['chemical-plant'],
         'oil-processing': ['oil-refinery'],
@@ -53,21 +55,36 @@ define(['knockout', 'text!./database.html', 'jquery',
         //debugger;
         for (var i = 0, len = data.length; i < len; i++) {
             var dataitem = data[i];
-            var dificultInfo = dataitem.normal || dataitem;
+            if(!!dataitem.normal){
+                result.push({
+                    id: dataitem.name,
+                    building: building_map[dataitem.category] || building_map["crafting"],
+                    normal: parseDifficulty(dataitem.normal),
+                    expensive: parseDifficulty(dataitem.expensive)
+                });
+            } else {
+                result.push($.extend({
+                        id: dataitem.name,
+                        building: building_map[dataitem.category] || building_map["crafting"]
+                    }                    
+                    ,parseDifficulty(dataitem)
+                ));
+            }
 
-            result.push({
-                id: dataitem.name,
-                time: dificultInfo.energy_required | 0.5,
-                building: building_map[dataitem.category] || building_map["crafting"],
-                input: parseIngredients(dificultInfo.ingredients),
-                output: parseIngredients(dificultInfo.result || dificultInfo.results, dificultInfo.result_count)
-            });
         }
 
         //debugger;
         var existing = JSON.parse(this.collection() || "[]");
         Array.prototype.push.apply(existing, result);
         this.collection(JSON.stringify(existing));
+    }
+
+    function parseDifficulty(item){
+        return {
+            time: item.energy_required || 0.5,
+            input: parseIngredients(item.ingredients),
+            output: parseIngredients(item.result || item.results, item.result_count)
+        }
     }
 
     function parseIngredients(ingredients, item_count) {

--- a/src/components/production/production-row.html
+++ b/src/components/production/production-row.html
@@ -104,6 +104,7 @@
                 building: building,
                 children: children,
             
+                expensiveRecipes: $parent.expensiveRecipes,
                 calculateCycle: $parent.options.calculateCycle,
                 cycleLength: $parent.options.cycleLength,
                 calculateBuildings: $parent.options.calculateBuildings,

--- a/src/components/production/production-row.js
+++ b/src/components/production/production-row.js
@@ -1,4 +1,4 @@
-define(['knockout', 'text!./production-row.html', 'data', 'app/formulae', 'i18n'], function(ko, template, $d, $f, $i) {
+define(['knockout', 'text!./production-row.html', 'data', 'app/formulae', 'i18n', 'app/recipes'], function(ko, template, $d, $f, $i, $r) {
 
     function ProductionRowViewModel(params) {
         var $self = this;
@@ -13,6 +13,7 @@ define(['knockout', 'text!./production-row.html', 'data', 'app/formulae', 'i18n'
         };
         $self.module = params.module;
         $self.children = params.children;
+        $self.expensiveRecipes = params.expensiveRecipes;
         $self.inputProduction = {};
         $self.header = $i(params.recipe.id)||params.recipe.id;
         $self.supply = ko.observable();
@@ -28,7 +29,7 @@ define(['knockout', 'text!./production-row.html', 'data', 'app/formulae', 'i18n'
                 return params.visible() && params.visibleParent()
             }),
             visibleParent: params.visibleParent,
-            hasInputs: ko.computed(() => Object.keys($self.recipe.input || {}).length > 0),
+            hasInputs: ko.computed(() => Object.keys($r.GetRecipeInput($self.recipe, $self.expensiveRecipes()) || {}).length > 0),
             hasSupply: ko.computed(() => Object.keys($self.supply() || {}).length > 0),
             hasChildren: ko.computed(() => $self.children().length > 0),
 
@@ -140,7 +141,7 @@ define(['knockout', 'text!./production-row.html', 'data', 'app/formulae', 'i18n'
             var cycleLength = $self.options.cycleLength();
             var numberOfBuildings = $self.options.numberOfBuildings();
 
-            var inputs = $f.GetInputPerSecond($self.recipe, $self.building.selected, $f.GetSpeedMultiplier($self.module));
+            var inputs = $f.GetInputPerSecond($self.recipe, $self.building.selected, $f.GetSpeedMultiplier($self.module), $self.expensiveRecipes);
             var length = Object.keys(inputs).length;
             var size = 'col-lg-' + Math.round(12 / length) + ' col-sm-' + Math.round(24 / length);
 
@@ -163,7 +164,7 @@ define(['knockout', 'text!./production-row.html', 'data', 'app/formulae', 'i18n'
             var cycleLength = $self.options.cycleLength();
             var numberOfBuildings = $self.options.numberOfBuildings();
 
-            var inputs = $f.GetOutputPerSecond($self.recipe, $self.building.selected, $f.GetSpeedMultiplier($self.module), $f.GetProductionMultiplier($self.module));
+            var inputs = $f.GetOutputPerSecond($self.recipe, $self.building.selected, $f.GetSpeedMultiplier($self.module), $f.GetProductionMultiplier($self.module), $self.expensiveRecipes);
             var size = 'col-sm-' + Math.round(12 / Object.keys(inputs).length);
             for (var k in inputs) {
                 result.push({

--- a/src/components/production/production-table.html
+++ b/src/components/production/production-table.html
@@ -11,6 +11,7 @@
             cycleLength:            $parent.cycleLength, 
             calculateBuildings:     $parent.calculateBuildings, 
             numberOfBuildings:      $parent.numberOfBuildings,
+            expensiveRecipes:       $parent.expensiveRecipes,
             
             visible:                function() { return true; }, /* items added by the user are always visible */
             visibleParent:          function() { return true; }, /* there's not Parent for itens added by users */

--- a/src/components/production/production-table.js
+++ b/src/components/production/production-table.js
@@ -9,6 +9,7 @@ define(['knockout', 'text!./production-table.html'], function(ko, template) {
         $self.numberOfBuildings = params.numberOfBuildings;
         $self.removeRecipeClick = params.removeRecipeClick;
         $self.includeChildrenClick = params.includeChildrenClick;
+        $self.expensiveRecipes = params.expensiveRecipes;
     }
 
 

--- a/src/components/recipe/selection-recipe.html
+++ b/src/components/recipe/selection-recipe.html
@@ -9,31 +9,31 @@
             </select>
         </div>
 
-        <div class="col-sm-3" data-bind="with:selectedRecipe">
+        <div class="col-sm-3">
             <label>Time</label>
             <div class="input-group" title="Time">
                 <span class="input-group-addon">
             <span class="glyphicon glyphicon-time"></span>
                 </span>
-                <input class="form-control readonly" readonly data-bind="value:time">
+                <input class="form-control readonly" readonly data-bind="value: time()">
             </div>
         </div>
 
-        <div class="col-sm-6" data-bind="with:selectedRecipe">
-            <label data-bind="text:('Output'+$parent.outputText())"></label>
+        <div class="col-sm-6">
+            <label data-bind="text:('Output'+outputText())"></label>
             <div class="row form-inline">
-                <!-- ko foreach:Object.keys(output) -->
-                <item-icon params="id: $data, value:$parent.output[$data], readonly:1" data-bind="css:$parents[1].outputSize"></item-icon>
+                <!-- ko foreach:Object.keys(output()) -->
+                <item-icon params="id: $data, value: $parent.output()[$data], readonly:1" data-bind="css:$parent.outputSize()"></item-icon>
                 <!-- /ko -->
             </div>
         </div>
     </div>
 
-    <div data-bind="with:selectedRecipe">
+    <div>
         <label>Input</label>
         <div class="row form-inline">
-            <!-- ko foreach:Object.keys(input) -->
-            <item-icon params="id: $data, value:$parent.input[$data], readonly:1" data-bind="css:$parents[1].inputSize"></item-icon>
+            <!-- ko foreach:Object.keys(input()) -->
+            <item-icon params="id: $data, value:$parent.input()[$data], readonly:1" data-bind="css:$parent.inputSize()"></item-icon>
             <!-- /ko -->
         </div>
     </div>

--- a/src/components/recipe/selection-recipe.js
+++ b/src/components/recipe/selection-recipe.js
@@ -1,4 +1,4 @@
-define(['knockout', 'text!./selection-recipe.html', 'data', 'app/formulae'], function(ko, template, dataLoader, $f) {
+define(['knockout', 'text!./selection-recipe.html', 'data', 'app/formulae', 'app/recipes'], function(ko, template, dataLoader, $f, $r) {
 
     var MAX_SIZE = 12;
 
@@ -6,14 +6,42 @@ define(['knockout', 'text!./selection-recipe.html', 'data', 'app/formulae'], fun
         var $self = this;
         $self.selectedRecipe = params.selectedRecipe;
         $self.selectedModules = params.selectedModules;
+        $self.expensiveRecipes = params.expensiveRecipes;
         $self.availableRecipes = dataLoader.recipes.available;
+
+        $self.input = ko.computed(function() {
+            var selectedRecipe = $self.selectedRecipe();
+            if (!!selectedRecipe) {
+                return $r.GetRecipeInput(selectedRecipe, $self.expensiveRecipes());
+            } else {
+                return {};
+            }
+        });
+
+        $self.time = ko.computed(function() {
+            var selectedRecipe = $self.selectedRecipe();
+            if (!!selectedRecipe) {
+                return $r.GetRecipeTime(selectedRecipe, $self.expensiveRecipes());
+            } else {
+                return {};
+            }
+        });
+
+        $self.output = ko.computed(function() {
+            var selectedRecipe = $self.selectedRecipe();
+            if (!!selectedRecipe) {
+                return $r.GetRecipeOutput(selectedRecipe, $self.expensiveRecipes());
+            } else {
+                return {};
+            }
+        });
 
         $self.inputSize = ko.computed(function() {
             var selectedRecipe = $self.selectedRecipe();
             var size = 0;
             var length = 0;
             if (!!selectedRecipe) {
-                length = Object.keys(selectedRecipe.input).length;
+                length = Object.keys($r.GetRecipeInput(selectedRecipe, $self.expensiveRecipes())).length;
                 size = Math.floor(MAX_SIZE / length);
             }
             return "col-sm-" + (length > 4 ? size * 2 : size) + " col-lg-" + size;
@@ -22,7 +50,7 @@ define(['knockout', 'text!./selection-recipe.html', 'data', 'app/formulae'], fun
             var selectedRecipe = $self.selectedRecipe();
             var size = 0;
             if (!!selectedRecipe) {
-                size = Math.floor(MAX_SIZE / Object.keys(selectedRecipe.output).length);
+                size = Math.floor(MAX_SIZE / Object.keys($r.GetRecipeOutput(selectedRecipe, $self.expensiveRecipes())).length);
             }
             return "col-sm-" + (length > 4 ? size * 2 : size) + " col-lg-" + size;
         });

--- a/src/components/statistic-view/statistic-view.js
+++ b/src/components/statistic-view/statistic-view.js
@@ -17,6 +17,7 @@ define(['knockout', 'text!./statistic-view.html', 'app/formulae'], function(ko, 
 
         $self.calculateCycle = params.calculateCycle;
         $self.calculateBuildings = params.calculateBuildings;
+        $self.expensiveRecipes = params.expensiveRecipes;
         $self.buildingProperties = ko.computed($self.computeBuilding(params));
         $self.inputProperties = ko.computed($self.computeInput(params));
         $self.outputProperties = ko.computed($self.computeOutput(params));
@@ -74,7 +75,7 @@ define(['knockout', 'text!./statistic-view.html', 'app/formulae'], function(ko, 
             var cycleLength = params.calculateCycle() ? params.cycleLength() : 1;
             var numberOfBuildings = params.calculateBuildings() ? params.numberOfBuildings() : 1;
 
-            var inputs = $f.GetInputPerSecond(params.selectedRecipe, params.selectedBuilding, $f.GetSpeedMultiplier(params.selectedModules));
+            var inputs = $f.GetInputPerSecond(params.selectedRecipe, params.selectedBuilding, $f.GetSpeedMultiplier(params.selectedModules), params.expensiveRecipes);
             for (var k in inputs) {
                 result.push({
                     name: k,
@@ -91,7 +92,7 @@ define(['knockout', 'text!./statistic-view.html', 'app/formulae'], function(ko, 
             var cycleLength = params.calculateCycle() ? params.cycleLength() : 1;
             var numberOfBuildings = params.calculateBuildings() ? params.numberOfBuildings() : 1;
 
-            var inputs = $f.GetOutputPerSecond(params.selectedRecipe, params.selectedBuilding, $f.GetSpeedMultiplier(params.selectedModules), $f.GetProductionMultiplier(params.selectedModules));
+            var inputs = $f.GetOutputPerSecond(params.selectedRecipe, params.selectedBuilding, $f.GetSpeedMultiplier(params.selectedModules), $f.GetProductionMultiplier(params.selectedModules), params.expensiveRecipes);
             for (var k in inputs) {
                 result.push({
                     name: k,


### PR DESCRIPTION
Added a checkbox next to cycle length.
Updated database generator to process expensive recipes into two objects inside recipe objects.
Encountered issue with i18n no filtering description lang tags properly thus translating names into technology descriptions even though I haven't touched this logic.
Production-row doesn't update production per second properly when changing marathon states.
Also fixed two other issues:
space parts created by rocket silos
crafting-with-fluids wasn't processed properly which allowed crafting with fluids in assembling machine 1